### PR TITLE
Add Keys field for Collection

### DIFF
--- a/src/main/java/org/restheart/db/DBCursorPool.java
+++ b/src/main/java/org/restheart/db/DBCursorPool.java
@@ -157,14 +157,14 @@ public class DBCursorPool {
 
             for (int tohave : SKIP_SLICES_HEIGHTS) {
                 int sliceSkips = slice * SKIP_SLICE_LINEAR_WIDTH - SKIP_SLICE_LINEAR_DELTA;
-                DBCursorPoolEntryKey sliceKey = new DBCursorPoolEntryKey(key.getCollection(), key.getSort(), key.getFilter(), sliceSkips, -1);
+                DBCursorPoolEntryKey sliceKey = new DBCursorPoolEntryKey(key.getCollection(), key.getSort(), key.getFilter(), key.getFilter(), sliceSkips, -1);
 
                 long existing = getSliceHeight(sliceKey);
 
                 for (long cont = tohave - existing; cont > 0; cont--) {
-                    DBCursor cursor = dbsDAO.getCollectionDBCursor(key.getCollection(), key.getSort(), key.getFilter());
+                    DBCursor cursor = dbsDAO.getCollectionDBCursor(key.getCollection(), key.getSort(), key.getFilter(), key.getKeys());
                     cursor.skip(sliceSkips);
-                    DBCursorPoolEntryKey newkey = new DBCursorPoolEntryKey(key.getCollection(), key.getSort(), key.getFilter(), sliceSkips, System.nanoTime());
+                    DBCursorPoolEntryKey newkey = new DBCursorPoolEntryKey(key.getCollection(), key.getSort(), key.getFilter(), key.getKeys(), sliceSkips, System.nanoTime());
                     cache.put(newkey, cursor);
                     LOGGER.debug("created new cursor in pool: {}", newkey);
                 }
@@ -193,14 +193,14 @@ public class DBCursorPool {
             for (int slice = 1; slice < slices; slice++) {
                 int sliceSkips = (int) slice * sliceWidht;
 
-                DBCursorPoolEntryKey sliceKey = new DBCursorPoolEntryKey(key.getCollection(), key.getSort(), key.getFilter(), sliceSkips, -1);
+                DBCursorPoolEntryKey sliceKey = new DBCursorPoolEntryKey(key.getCollection(), key.getSort(), key.getFilter(), key.getKeys(), sliceSkips, -1);
 
                 long existing = getSliceHeight(sliceKey);
 
                 for (long cont = 1 - existing; cont > 0; cont--) {
-                    DBCursor cursor = dbsDAO.getCollectionDBCursor(key.getCollection(), key.getSort(), key.getFilter());
+                    DBCursor cursor = dbsDAO.getCollectionDBCursor(key.getCollection(), key.getSort(), key.getFilter(), key.getKeys());
                     cursor.skip(sliceSkips);
-                    DBCursorPoolEntryKey newkey = new DBCursorPoolEntryKey(key.getCollection(), key.getSort(), key.getFilter(), sliceSkips, System.nanoTime());
+                    DBCursorPoolEntryKey newkey = new DBCursorPoolEntryKey(key.getCollection(), key.getSort(), key.getFilter(), key.getKeys(), sliceSkips, System.nanoTime());
                     cache.put(newkey, cursor);
                     LOGGER.debug("created new cursor in pool: {}", newkey);
                 }

--- a/src/main/java/org/restheart/db/DBCursorPoolEntryKey.java
+++ b/src/main/java/org/restheart/db/DBCursorPoolEntryKey.java
@@ -18,6 +18,7 @@
 package org.restheart.db;
 
 import com.mongodb.DBCollection;
+
 import java.util.Deque;
 import java.util.Formatter;
 import java.util.Objects;
@@ -30,12 +31,14 @@ public class DBCursorPoolEntryKey {
     private final DBCollection collection;
     private final Deque<String> sort;
     private final Deque<String> filter;
+    private final Deque<String> keys;
     private final int skipped;
     private final long cursorId;
 
-    public DBCursorPoolEntryKey(DBCollection collection, Deque<String> sort, Deque<String> filter, int skipped, long cursorId) {
+    public DBCursorPoolEntryKey(DBCollection collection, Deque<String> sort, Deque<String> filter, Deque<String> keys, int skipped, long cursorId) {
         this.collection = collection;
         this.filter = filter;
+        this.keys = keys;
         this.sort = sort;
         this.skipped = skipped;
         this.cursorId = cursorId;
@@ -75,10 +78,17 @@ public class DBCursorPoolEntryKey {
     public long getCursorId() {
         return cursorId;
     }
-    
-    @Override
+
+    /**
+     * @return keys
+     */
+	public Deque<String> getKeys() {
+		return keys;
+	}    
+
+	@Override
     public int hashCode() {
-        return Objects.hash(collection, filter, sort, skipped, cursorId);
+        return Objects.hash(collection, filter, keys, sort, skipped, cursorId);
     }
 
     @Override
@@ -96,6 +106,9 @@ public class DBCursorPoolEntryKey {
         if (!Objects.equals(this.filter, other.filter)) {
             return false;
         }
+        if (!Objects.equals(this.keys, other.keys)) {
+            return false;
+        }
         if (!Objects.equals(this.sort, other.sort)) {
             return false;
         }
@@ -107,7 +120,7 @@ public class DBCursorPoolEntryKey {
         }
         return true;
     }
-
+    
     @Override
     public String toString() {
         return "{ collection: " + collection.getFullName() + ", " +
@@ -122,4 +135,6 @@ public class DBCursorPoolEntryKey {
         
         return (filter == null ? "no filter" : filter.toString()) + " - " + (sort == null ? "no sort_by" : sort.toString()) + " - " + f.format("%10d", getSkipped());
     }
+
+
 }

--- a/src/main/java/org/restheart/db/Database.java
+++ b/src/main/java/org/restheart/db/Database.java
@@ -23,10 +23,13 @@ import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import com.mongodb.util.JSONParseException;
+
 import io.undertow.server.HttpServerExchange;
+
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
+
 import org.bson.types.ObjectId;
 import org.restheart.handlers.IllegalQueryParamenterException;
 
@@ -82,7 +85,7 @@ public interface Database {
      * @param cursorAllocationPolicy
      * @return Collection Data as ArrayList of DBObject
      */
-    ArrayList<DBObject> getCollectionData(DBCollection collection, int page, int pagesize, Deque<String> sortBy, Deque<String> filter, DBCursorPool.EAGER_CURSOR_ALLOCATION_POLICY cursorAllocationPolicy);
+    ArrayList<DBObject> getCollectionData(DBCollection collection, int page, int pagesize, Deque<String> sortBy, Deque<String> filter,Deque<String> keys, DBCursorPool.EAGER_CURSOR_ALLOCATION_POLICY cursorAllocationPolicy);
 
     /**
      *
@@ -210,7 +213,7 @@ public interface Database {
      * @return
      * @throws JSONParseException
      */
-    DBCursor getCollectionDBCursor(DBCollection collection, Deque<String> sortBy, Deque<String> filters) throws JSONParseException;
+    DBCursor getCollectionDBCursor(DBCollection collection, Deque<String> sortBy, Deque<String> filters, Deque<String> keys) throws JSONParseException;
 
     /**
      *
@@ -220,4 +223,5 @@ public interface Database {
      * @param options
      */
     void createIndex(String dbName, String collection, DBObject keys, DBObject options);
+
 }

--- a/src/main/java/org/restheart/db/DbsDAO.java
+++ b/src/main/java/org/restheart/db/DbsDAO.java
@@ -23,17 +23,21 @@ import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import com.mongodb.MongoClient;
+
 import org.restheart.utils.HttpStatus;
 import org.restheart.handlers.IllegalQueryParamenterException;
 import org.restheart.handlers.RequestContext;
 import org.restheart.handlers.injectors.LocalCachesSingleton;
 import org.restheart.utils.ResponseHelper;
+
 import io.undertow.server.HttpServerExchange;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.bson.types.ObjectId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -386,8 +390,8 @@ public class DbsDAO implements Database {
     }
 
     @Override
-    public ArrayList<DBObject> getCollectionData(DBCollection coll, int page, int pagesize, Deque<String> sortBy, Deque<String> filter, DBCursorPool.EAGER_CURSOR_ALLOCATION_POLICY cursorAllocationPolicy) {
-        return collectionDAO.getCollectionData(coll, page, pagesize, sortBy, filter, cursorAllocationPolicy);
+    public ArrayList<DBObject> getCollectionData(DBCollection coll, int page, int pagesize, Deque<String> sortBy, Deque<String> filter,Deque<String> keys, DBCursorPool.EAGER_CURSOR_ALLOCATION_POLICY cursorAllocationPolicy) {
+        return collectionDAO.getCollectionData(coll, page, pagesize, sortBy, filter, keys, cursorAllocationPolicy);
     }
 
     @Override
@@ -406,8 +410,8 @@ public class DbsDAO implements Database {
     }
 
     @Override
-    public DBCursor getCollectionDBCursor(DBCollection collection, Deque<String> sortBy, Deque<String> filters) {
-        return collectionDAO.getCollectionDBCursor(collection, sortBy, filters);
+    public DBCursor getCollectionDBCursor(DBCollection collection, Deque<String> sortBy, Deque<String> filters, Deque<String> keys ) {
+        return collectionDAO.getCollectionDBCursor(collection, sortBy, filters, keys);
     }
 
     @Override

--- a/src/main/java/org/restheart/handlers/RequestContext.java
+++ b/src/main/java/org/restheart/handlers/RequestContext.java
@@ -75,6 +75,7 @@ public class RequestContext {
     public static final String COUNT_QPARAM_KEY = "count";
     public static final String SORT_BY_QPARAM_KEY = "sort_by";
     public static final String FILTER_QPARAM_KEY = "filter";
+    public static final String KEYS_QPARAM_KEY = "keys";
     public static final String EAGER_CURSOR_ALLOCATION_POLICY_QPARAM_KEY = "eager";
     public static final String DOC_ID_TYPE_KEY = "id_type";
     public static final String SLASH = "/";
@@ -114,6 +115,7 @@ public class RequestContext {
     private boolean count = false;
     private EAGER_CURSOR_ALLOCATION_POLICY cursorAllocationPolicy;
     private Deque<String> filter = null;
+    private Deque<String> keys = null;
     private Deque<String> sortBy = null;
     private DOC_ID_TYPE docIdType = DOC_ID_TYPE.STRING_OID;
     private Object documentId;
@@ -626,4 +628,17 @@ public class RequestContext {
     public void setFile(File file) {
         this.file = file;
     }
+    
+    /**
+     * @return keys
+     */
+	public Deque<String> getKeys() {
+		return keys;
+	}
+    /**
+     * @param keys keys to set
+     */
+	public void setKeys(Deque<String> keys) {
+		this.keys = keys;
+	}
 }

--- a/src/main/java/org/restheart/handlers/collection/GetCollectionHandler.java
+++ b/src/main/java/org/restheart/handlers/collection/GetCollectionHandler.java
@@ -76,7 +76,7 @@ public class GetCollectionHandler extends PipedHttpHandler {
 
             try {
                 data = getDatabase().getCollectionData(coll, context.getPage(), context.getPagesize(),
-                        context.getSortBy(), context.getFilter(), context.getCursorAllocationPolicy());
+                        context.getSortBy(), context.getFilter(), context.getKeys(), context.getCursorAllocationPolicy());
             } catch (JSONParseException jpe) {
                 // the filter expression is not a valid json string
                 LOGGER.debug("invalid filter expression {}", context.getFilter(), jpe);

--- a/src/test/java/org/restheart/test/performance/LoadGetPT.java
+++ b/src/test/java/org/restheart/test/performance/LoadGetPT.java
@@ -149,6 +149,7 @@ public class LoadGetPT {
         DBCollection dbcoll = dbsDAO.getCollection(db, coll);
 
         Deque<String> _filter;
+        Deque<String> _keys = null;
 
         if (filter == null) {
             _filter = null;
@@ -160,7 +161,7 @@ public class LoadGetPT {
         ArrayList<DBObject> data;
         
         try {
-            data = new DbsDAO().getCollectionData(dbcoll, page, pagesize, null, _filter, DBCursorPool.EAGER_CURSOR_ALLOCATION_POLICY.NONE);
+            data = new DbsDAO().getCollectionData(dbcoll, page, pagesize, null, _filter, _keys, DBCursorPool.EAGER_CURSOR_ALLOCATION_POLICY.NONE);
         } catch(Exception e) {
             System.out.println("error: " + e.getMessage());
             return;


### PR DESCRIPTION
This patch adds a new GET query parameter keys which allows to specify
a list of JSON fields which should be returned as a query result.
/data/collection?keys={'field':1}
will return JSON containing only 'field' elements from the original documents. All filed starting with '_' will be preserved in the output.