### PR TITLE
Adding private constructor to util classes (containing  static methods only)

### DIFF
--- a/src/main/java/org/restheart/Bootstrapper.java
+++ b/src/main/java/org/restheart/Bootstrapper.java
@@ -102,6 +102,9 @@ public final class Bootstrapper {
     private static GracefulShutdownHandler shutdownHandler = null;
     private static Configuration configuration;
 
+    private Bootstrapper() {
+    }
+
     /**
      * main method
      *

--- a/src/main/java/org/restheart/ConfigurationHelper.java
+++ b/src/main/java/org/restheart/ConfigurationHelper.java
@@ -37,6 +37,9 @@ public class ConfigurationHelper {
 
     private static final Set<Option> LONG_UNDERTOW_OPTIONS;
 
+    private ConfigurationHelper() {
+    }
+
     static {
         UNDERTOW_OPTIONS = Sets.newHashSet();
         UNDERTOW_OPTIONS.add(UndertowOptions.ALLOW_ENCODED_SLASH);

--- a/src/main/java/org/restheart/Shutdowner.java
+++ b/src/main/java/org/restheart/Shutdowner.java
@@ -31,6 +31,9 @@ import org.slf4j.LoggerFactory;
 public class Shutdowner {
     private static final Logger LOGGER = LoggerFactory.getLogger(Shutdowner.class);
 
+    private Shutdowner() {
+    }
+
     public static void main(final String[] args) {
         if (askingForHelp(args)) {
             LOGGER.info("usage: java -cp restheart.jar org.restheart.Shutdowner [configuration file].");

--- a/src/main/java/org/restheart/db/DAOUtils.java
+++ b/src/main/java/org/restheart/db/DAOUtils.java
@@ -70,6 +70,9 @@ public class DAOUtils {
             = new UpdateOptions()
             .upsert(false);
 
+    private DAOUtils() {
+    }
+
     /**
      * @param rows list of DBObject rows as returned by getDataFromCursor()
      * @return

--- a/src/main/java/org/restheart/hal/HALUtils.java
+++ b/src/main/java/org/restheart/hal/HALUtils.java
@@ -28,6 +28,10 @@ import java.util.TreeMap;
  * @author Andrea Di Cesare {@literal <andrea@softinstigate.com>}
  */
 public class HALUtils {
+
+    private HALUtils() {
+    }
+
     /**
      *
      * @param exchange

--- a/src/main/java/org/restheart/hal/metadata/singletons/CheckersUtils.java
+++ b/src/main/java/org/restheart/hal/metadata/singletons/CheckersUtils.java
@@ -28,6 +28,10 @@ import static org.restheart.utils.RequestHelper.UPDATE_OPERATORS;
  * @author Andrea Di Cesare {@literal <andrea@softinstigate.com>}
  */
 public class CheckersUtils {
+
+    private CheckersUtils() {
+    }
+
     public static boolean isBulkRequest(RequestContext context) {
         return context.getType() == RequestContext.TYPE.BULK_DOCUMENTS
                 || context.getContent() instanceof BasicDBList;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “ Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.