### PR TITLE
upgrading to org.everit.json.schema:1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>org.everit.json</groupId>
             <artifactId>org.everit.json.schema</artifactId>
-            <version>1.1.1</version>
+            <version>1.2.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
[1.2.0 has been released](https://github.com/everit-org/json-schema/releases/tag/1.2.0) yesterday, has some improvements and bugfixes (not sure if you need these though) 