### PR TITLE
upgrading to everit-org/json-schema 1.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>org.everit.json</groupId>
             <artifactId>org.everit.json.schema</artifactId>
-            <version>1.3.0</version>
+            <version>1.4.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Version 1.3.0 is a bit outdated, so I thought it would be better for RESTHeart to update. The changelogs of version 1.4.0 and 1.4.1 can be found [here](https://github.com/everit-org/json-schema/releases)