### PR TITLE
upgrading to everit-org/json-schema 1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>org.everit.json</groupId>
             <artifactId>org.everit.json.schema</artifactId>
-            <version>1.4.1</version>
+            <version>1.5.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Version [1.5.0](https://github.com/everit-org/json-schema/releases/tag/1.5.0) contains some compliance fixes, so it is better to upgrade.