### PR TITLE
#199 Fixed Logging Issue with Logback

### DIFF
--- a/src/main/java/org/restheart/Bootstrapper.java
+++ b/src/main/java/org/restheart/Bootstrapper.java
@@ -296,6 +296,11 @@ public final class Bootstrapper {
      * @param fork
      */
     private static void logLoggingConfiguration(boolean fork) {
+        String logbackConfigurationFile = System.getProperty("logback.configurationFile");
+        boolean usesLogback = logbackConfigurationFile != null && !logbackConfigurationFile.equals("");
+        
+        if(usesLogback) return;
+        
         if (configuration.isLogToFile()) {
             LOGGER.info("Logging to file {} with level {}", configuration.getLogFilePath(), configuration.getLogLevel());
         }

--- a/src/main/java/org/restheart/Configuration.java
+++ b/src/main/java/org/restheart/Configuration.java
@@ -18,7 +18,10 @@
 package org.restheart;
 
 import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+
 import com.google.common.collect.Maps;
+
 import com.mongodb.MongoClientURI;
 import org.restheart.utils.URLUtils;
 import java.io.File;
@@ -1223,6 +1226,14 @@ public class Configuration {
      * @return the logLevel
      */
     public final Level getLogLevel() {
+        
+        String logbackConfigurationFile = System.getProperty("logback.configurationFile");
+        if (logbackConfigurationFile != null && !logbackConfigurationFile.equals("")) {
+            LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+            ch.qos.logback.classic.Logger logger = loggerContext.getLogger("org.restheart");
+            return logger.getLevel();
+        }
+        
         return logLevel;
     }
 

--- a/src/main/java/org/restheart/utils/LoggingInitializer.java
+++ b/src/main/java/org/restheart/utils/LoggingInitializer.java
@@ -46,7 +46,13 @@ public class LoggingInitializer {
     public static void setLogLevel(Level level) {
         LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
         Logger logger = loggerContext.getLogger("org.restheart");
-
+        
+        String logbackConfigurationFile = System.getProperty("logback.configurationFile");
+        if (logbackConfigurationFile != null && !logbackConfigurationFile.equals("")) {
+            logger.info("Loglevel was set via logback configuration file with level {}", logger.getLevel());
+            level = logger.getLevel();
+        }
+        
         logger.setLevel(level);
     }
 


### PR DESCRIPTION
Restheart used to override the Loglevel from a given logback.xml (see #199).

This solution fixes the problem, if the system property _ logback.configurationFile_  is set.
In case that the property is not set, restheart's behavior does not change. 

1. In src/main/java/org/restheart/Bootstrapper.java I changed the logLoggingConfiguration(), so it will be skipped, if logback is used.

2. In src/main/java/org/restheart/Configuration.java I changed the default behavior of getLogLevel() , such that it returns the loglevel of the logback configuration file, if it is set.

3. In src/main/java/org/restheart/utils/LoggingInitializer.java I changed the setLogLevel() method, so it will not override an existing setting from the logback.xml if it is set.

(I would read the logback.xml and write its settings into the configuration, but I thought it shouldn't be touched)

A topic to discuss: Wouldn't it be better, if the logging settings would be configurated somewhere else then inside of the .yml ?

