### PR TITLE
upgrading to everit-org/json-schema 1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         </dependency>
 
         <dependency>
-            <groupId>org.everit.json</groupId>
+            <groupId>com.github.everit-org.json-schema</groupId>
             <artifactId>org.everit.json.schema</artifactId>
             <version>1.6.0</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,13 @@
         </repository>
     </distributionManagement>
 
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+    
     <scm>
         <url>https://github.com/SoftInstigate/restheart</url>
         <connection>scm:git:git@github.com:SoftInstigate/restheart.git</connection>
@@ -147,7 +154,7 @@
         <dependency>
             <groupId>org.everit.json</groupId>
             <artifactId>org.everit.json.schema</artifactId>
-            <version>1.5.1</version>
+            <version>1.6.0</version>
         </dependency>
         
         <dependency>


### PR DESCRIPTION
This was a major release, with JSON Schema Draft 6 support as its main new feature.

Release notes can be found [here](https://github.com/everit-org/json-schema/releases/tag/1.6.0)

It is distributed through JitPack instead of Maven Central. I hope it doesn't cause any problems for you.