### PR TITLE
RH-64 - Editing metadata for binary files

### DIFF
--- a/src/main/java/org/restheart/Configuration.java
+++ b/src/main/java/org/restheart/Configuration.java
@@ -531,9 +531,9 @@ public class Configuration {
      * @param integers
      * @return
      */
-    public static int[] convertListToIntArray(List integers) {
+    public static int[] convertListToIntArray(List<Object> integers) {
         int[] ret = new int[integers.size()];
-        Iterator iterator = integers.iterator();
+        Iterator<Object> iterator = integers.iterator();
         for (int i = 0; i < ret.length; i++) {
             Object o = iterator.next();
 
@@ -1002,7 +1002,6 @@ public class Configuration {
      * @param defaultValue
      * @return
      */
-    @SuppressWarnings("unchecked")
     private Boolean getAsBooleanOrDefault(final Map<String, Object> conf, final String key, final Boolean defaultValue) {
         if (conf == null) {
             if (!silent) {
@@ -1039,7 +1038,6 @@ public class Configuration {
      * @param defaultValue
      * @return
      */
-    @SuppressWarnings("unchecked")
     private String getAsStringOrDefault(final Map<String, Object> conf, final String key, final String defaultValue) {
 
         if (conf == null || conf.get(key) == null) {
@@ -1068,7 +1066,6 @@ public class Configuration {
      * @param defaultValue
      * @return
      */
-    @SuppressWarnings("unchecked")
     private Integer getAsIntegerOrDefault(final Map<String, Object> conf, final String key, final Integer defaultValue) {
         if (conf == null || conf.get(key) == null) {
             // if default value is null there is no default value actually
@@ -1096,7 +1093,6 @@ public class Configuration {
      * @param defaultValue
      * @return
      */
-    @SuppressWarnings("unchecked")
     private Long getAsLongOrDefault(final Map<String, Object> conf, final String key, final Long defaultValue) {
         if (conf == null || conf.get(key) == null) {
             // if default value is null there is no default value actually
@@ -1144,7 +1140,7 @@ public class Configuration {
                 LOGGER.debug("paramenter {} set to {}", key, conf.get(key));
             }
 
-            int ret[] = convertListToIntArray((List) conf.get(key));
+            int ret[] = convertListToIntArray((List<Object>) conf.get(key));
 
             if (ret.length == 0) {
                 if (!silent) {

--- a/src/main/java/org/restheart/db/DocumentDAO.java
+++ b/src/main/java/org/restheart/db/DocumentDAO.java
@@ -1,17 +1,17 @@
 /*
  * RESTHeart - the data Repository API server
  * Copyright (C) SoftInstigate Srl
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Andrea Di Cesare {@literal <andrea@softinstigate.com>}
  */
-public class DocumentDAO implements Repository {
+public class DocumentDAO implements DocumentRepository {
 
     private final Logger LOGGER = LoggerFactory.getLogger(DocumentDAO.class);
 
@@ -427,7 +427,8 @@ public class DocumentDAO implements Repository {
                         oldDocument.get("_id"),
                         shardKeys,
                         oldDocument,
-                        newEtag);
+                        newEtag,
+                        "_etag");
             }
 
             return new OperationResult(
@@ -467,7 +468,8 @@ public class DocumentDAO implements Repository {
                         oldDocument.get("_id"),
                         shardKeys,
                         oldDocument,
-                        newEtag);
+                        newEtag,
+                        "_etag");
             }
 
             return new OperationResult(

--- a/src/main/java/org/restheart/db/DocumentRepository.java
+++ b/src/main/java/org/restheart/db/DocumentRepository.java
@@ -1,0 +1,50 @@
+/*
+ * RESTHeart - the data Repository API server
+ * Copyright (C) SoftInstigate Srl
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.restheart.db;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.Document;
+
+/**
+ *
+ * @author Maurizio Turatti {@literal <maurizio@softinstigate.com>}
+ */
+public interface DocumentRepository {
+
+    OperationResult upsertDocument(final String dbName, final String collName, final Object documentId, final BsonDocument filter, final BsonDocument shardedKeys, final BsonDocument content, final String requestEtag, boolean patching, final boolean checkEtag);
+
+    OperationResult upsertDocumentPost(final String dbName, final String collName, final BsonDocument filter, final BsonDocument shardedKeys, final BsonDocument content, final String requestEtag, final boolean checkEtag);
+
+    OperationResult deleteDocument(final String dbName, String collName, Object documentId, final BsonDocument filter, final BsonDocument shardedKeys, final String requestEtag, final boolean checkEtag);
+
+    BulkOperationResult bulkUpsertDocumentsPost(final String dbName, final String collName, final BsonArray documents, final BsonDocument filter, final BsonDocument shardKeys);
+
+    BulkOperationResult bulkPatchDocuments(final String dbName, final String collName, final BsonDocument filter, final BsonDocument shardKeys, final BsonDocument data);
+
+    BulkOperationResult bulkDeleteDocuments(final String dbName, final String collName, final BsonDocument filter, final BsonDocument shardKeys);
+
+    /**
+     * returns the ETag of the document
+     * @param dbName
+     * @param collName
+     * @param documentId
+     * @return Document containing _etag property
+     */
+    Document getDocumentEtag(String dbName, String collName, Object documentId);
+}

--- a/src/main/java/org/restheart/db/FileMetadataDAO.java
+++ b/src/main/java/org/restheart/db/FileMetadataDAO.java
@@ -1,0 +1,183 @@
+/*
+ * RESTHeart - the data Repository API server
+ * Copyright (C) SoftInstigate Srl
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.restheart.db;
+
+import static com.mongodb.client.model.Filters.eq;
+
+import java.util.Objects;
+
+import org.bson.BsonDocument;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.types.ObjectId;
+import org.restheart.utils.HttpStatus;
+
+import com.mongodb.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+
+/**
+ * This DAO takes care of changes to metadata for binary files that have been created using GridFS.
+ *
+ * @author Nath Papadacis {@literal <nath@thirststudios.co.uk>}
+ */
+public class FileMetadataDAO implements FileMetadataRepository {
+
+    private final MongoClient client;
+
+    public FileMetadataDAO() {
+        client = MongoDBClientSingleton.getInstance().getClient();
+    }
+
+    @Override
+    public OperationResult updateMetadata(
+            final String dbName,
+            final String collName,
+            final Object documentId,
+            final BsonDocument filter,
+            final BsonDocument shardKeys,
+            final BsonDocument newContent,
+            final String requestEtag,
+            final boolean patching,
+            final boolean checkEtag) {
+        MongoDatabase mdb = client.getDatabase(dbName);
+        MongoCollection<BsonDocument> mcoll = mdb.getCollection(collName, BsonDocument.class);
+
+        // genereate new etag
+        ObjectId newEtag = new ObjectId();
+
+        final BsonDocument content = DAOUtils.validContent(newContent);
+        content.get("metadata", new BsonDocument()).asDocument().put("_etag", new BsonObjectId(newEtag));
+
+        OperationResult updateResult = DAOUtils.updateMetadata(
+                mcoll,
+                documentId,
+                filter,
+                shardKeys,
+                content,
+                patching);
+
+        BsonDocument oldDocument = updateResult.getOldData();
+
+        if (patching) {
+            if (oldDocument == null) { // Attempted an insert of a new doc.
+                return new OperationResult(
+                        updateResult.getHttpCode() > 0
+                                ? updateResult.getHttpCode()
+                                : HttpStatus.SC_CONFLICT, newEtag, null, updateResult.getNewData());
+            } else if (checkEtag) {
+                // check the old etag (in case restore the old document version)
+                return optimisticCheckEtag(
+                        mcoll,
+                        shardKeys,
+                        oldDocument,
+                        newEtag,
+                        requestEtag,
+                        HttpStatus.SC_OK);
+            } else {
+                BsonDocument newDocument = mcoll.find(
+                        eq("_id", documentId)).first();
+
+                return new OperationResult(updateResult.getHttpCode() > 0
+                        ? updateResult.getHttpCode()
+                        : HttpStatus.SC_OK, newEtag, oldDocument, newDocument);
+            }
+        } else if (oldDocument != null && checkEtag) { // update
+            // check the old etag (in case restore the old document)
+            return optimisticCheckEtag(
+                    mcoll,
+                    shardKeys,
+                    oldDocument,
+                    newEtag,
+                    requestEtag,
+                    HttpStatus.SC_OK);
+        } else if (oldDocument != null) {  // update
+            BsonDocument newDocument = mcoll.find(
+                    eq("_id", documentId)).first();
+
+            return new OperationResult(
+                    updateResult.getHttpCode() > 0
+                            ? updateResult.getHttpCode()
+                            : HttpStatus.SC_OK, newEtag, oldDocument, newDocument);
+        } else { // Attempted an insert of a new doc.
+            return new OperationResult(
+                    updateResult.getHttpCode() > 0
+                            ? updateResult.getHttpCode()
+                            : HttpStatus.SC_CONFLICT, newEtag, null, updateResult.getNewData());
+        }
+    }
+
+    private OperationResult optimisticCheckEtag(
+            final MongoCollection<BsonDocument> coll,
+            final BsonDocument shardKeys,
+            final BsonDocument oldDocument,
+            final Object newEtag,
+            final String requestEtag,
+            final int httpStatusIfOk) {
+
+        BsonValue oldEtag = oldDocument.get("metadata", new BsonDocument()).asDocument().get("_etag");
+
+        if (oldEtag != null && requestEtag == null) {
+            // oops, we need to restore old document
+            DAOUtils.restoreDocument(
+                    coll,
+                    oldDocument.get("_id"),
+                    shardKeys,
+                    oldDocument,
+                    newEtag,
+                    "metadata._etag");
+
+            return new OperationResult(
+                    HttpStatus.SC_CONFLICT, oldEtag, oldDocument, null);
+        }
+
+        BsonValue _requestEtag;
+
+        if (ObjectId.isValid(requestEtag)) {
+            _requestEtag = new BsonObjectId(new ObjectId(requestEtag));
+        } else {
+            // restheart generates ObjectId etags, but here we support
+            // strings as well
+            _requestEtag = new BsonString(requestEtag);
+        }
+
+        if (Objects.equals(_requestEtag, oldEtag)) {
+            BsonDocument newDocument = coll.find(
+                    eq("_id", oldDocument.get("_id"))).first();
+
+            return new OperationResult(
+                    httpStatusIfOk, newEtag, oldDocument, newDocument);
+        } else {
+            // oops, we need to restore old document
+            DAOUtils.restoreDocument(
+                    coll,
+                    oldDocument.get("_id"),
+                    shardKeys,
+                    oldDocument,
+                    newEtag,
+                    "metadata._etag");
+
+            return new OperationResult(
+                    HttpStatus.SC_PRECONDITION_FAILED,
+                    oldEtag,
+                    oldDocument,
+                    null);
+        }
+    }
+}

--- a/src/main/java/org/restheart/db/FileMetadataRepository.java
+++ b/src/main/java/org/restheart/db/FileMetadataRepository.java
@@ -1,0 +1,22 @@
+package org.restheart.db;
+
+import org.bson.BsonDocument;
+
+/**
+ *
+ * @author Nath Papadacis {@literal <nath@thirststudios.co.uk>}
+ */
+public interface FileMetadataRepository {
+
+    public abstract OperationResult updateMetadata(
+            String dbName,
+            String collName,
+            Object documentId,
+            BsonDocument filter,
+            BsonDocument shardKeys,
+            BsonDocument newContent,
+            String requestEtag,
+            boolean patching,
+            boolean checkEtag);
+
+}

--- a/src/main/java/org/restheart/db/GridFsDAO.java
+++ b/src/main/java/org/restheart/db/GridFsDAO.java
@@ -3,17 +3,17 @@ package org.restheart.db;
 /*
  * RESTHeart - the Web API for MongoDB
  * Copyright (C) SoftInstigate Srl
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -55,7 +55,6 @@ public class GridFsDAO implements GridFsRepository {
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     public OperationResult createFile(
             final Database db,
             final String dbName,

--- a/src/main/java/org/restheart/handlers/PipedHttpHandler.java
+++ b/src/main/java/org/restheart/handlers/PipedHttpHandler.java
@@ -5,7 +5,9 @@ import io.undertow.security.api.AuthenticationMode;
 import io.undertow.security.idm.IdentityManager;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
+
 import java.util.List;
+
 import org.restheart.db.Database;
 import org.restheart.db.DbsDAO;
 import org.restheart.security.AccessManager;
@@ -21,6 +23,12 @@ import org.restheart.security.handlers.SecurityInitialHandler;
  * @author Andrea Di Cesare {@literal <andrea@softinstigate.com>}
  */
 public abstract class PipedHttpHandler implements HttpHandler {
+
+    protected static final String PROPERTIES = "properties";
+    protected static final String FILE_METADATA = "metadata";
+    protected static final String _ID = "_id";
+    protected static final String CONTENT_TYPE = "contentType";
+    protected static final String FILENAME = "filename";
 
     protected static PipedHttpHandler buildSecurityHandlerChain(
             PipedHttpHandler next,

--- a/src/main/java/org/restheart/handlers/RequestDispacherHandler.java
+++ b/src/main/java/org/restheart/handlers/RequestDispacherHandler.java
@@ -1,25 +1,27 @@
 /*
  * RESTHeart - the Web API for MongoDB
  * Copyright (C) SoftInstigate Srl
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.restheart.handlers;
 
 import io.undertow.server.HttpServerExchange;
+
 import java.util.HashMap;
 import java.util.Map;
+
 import org.restheart.handlers.RequestContext.METHOD;
 import org.restheart.handlers.RequestContext.TYPE;
 import org.restheart.handlers.aggregation.AggregationTransformer;
@@ -42,6 +44,7 @@ import org.restheart.handlers.document.PatchDocumentHandler;
 import org.restheart.handlers.document.PutDocumentHandler;
 import org.restheart.handlers.files.DeleteBucketHandler;
 import org.restheart.handlers.files.DeleteFileHandler;
+import org.restheart.handlers.files.FileMetadataHandler;
 import org.restheart.handlers.files.GetFileBinaryHandler;
 import org.restheart.handlers.files.GetFileHandler;
 import org.restheart.handlers.files.PostBucketHandler;
@@ -284,6 +287,26 @@ public final class RequestDispacherHandler extends PipedHttpHandler {
                 new RequestTransformerMetadataHandler(
                         new DeleteFileHandler(
                                 respTransformers())));
+
+        // PUTting or PATCHing a file involves updating the metadata in the
+        // xxx.files bucket for an _id. Although the chunks are immutable we
+        // can treat the metadata like a regular document.
+        putPipedHttpHandler(TYPE.FILE, METHOD.PATCH,
+                new RequestTransformerMetadataHandler(
+                        new BeforeWriteCheckMetadataHandler(
+                                new FileMetadataHandler(
+                                        new AfterWriteCheckMetadataHandler(
+                                                respTransformers())))));
+
+        /*
+         * TODO There's already a PUT handler that allows custom id's to be set. Need to think about how to handle PUT with no binary data
+        putPipedHttpHandler(TYPE.FILE, METHOD.PUT,
+                new RequestTransformerMetadataHandler(
+                        new BeforeWriteCheckMetadataHandler(
+                                new FileMetadataHandler(
+                                        new AfterWriteCheckMetadataHandler(
+                                                respTransformers())))));
+         */
 
         // *** AGGREGATION handler
         putPipedHttpHandler(TYPE.AGGREGATION, METHOD.GET,

--- a/src/main/java/org/restheart/handlers/RequestDispacherHandler.java
+++ b/src/main/java/org/restheart/handlers/RequestDispacherHandler.java
@@ -262,7 +262,8 @@ public final class RequestDispacherHandler extends PipedHttpHandler {
                 new RequestTransformerMetadataHandler(
                         new BeforeWriteCheckMetadataHandler(
                                 new PutFileHandler(
-                                        respTransformers()))));
+                                        new FileMetadataHandler(
+                                                respTransformers())))));
 
         putPipedHttpHandler(TYPE.FILES_BUCKET, METHOD.PUT,
                 new RequestTransformerMetadataHandler(

--- a/src/main/java/org/restheart/handlers/document/PutDocumentHandler.java
+++ b/src/main/java/org/restheart/handlers/document/PutDocumentHandler.java
@@ -1,17 +1,17 @@
 /*
  * RESTHeart - the Web API for MongoDB
  * Copyright (C) SoftInstigate Srl
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */

--- a/src/main/java/org/restheart/handlers/files/FileMetadataHandler.java
+++ b/src/main/java/org/restheart/handlers/files/FileMetadataHandler.java
@@ -15,55 +15,58 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.restheart.handlers.document;
+package org.restheart.handlers.files;
 
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
+
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
-import org.restheart.db.DocumentDAO;
+import org.restheart.db.FileMetadataDAO;
+import org.restheart.db.FileMetadataRepository;
 import org.restheart.db.OperationResult;
 import org.restheart.handlers.PipedHttpHandler;
 import org.restheart.handlers.RequestContext;
+import org.restheart.handlers.RequestContext.METHOD;
 import org.restheart.utils.HttpStatus;
 import org.restheart.utils.ResponseHelper;
 
 /**
+ * A customised and cut down version of the {@link org.restheart.handlers.document.PutDocumentHandler PutDocumentHandler}
+ * or {@link org.restheart.handlers.document.PatchDocumentHandler PatchDocumentHandler}, this deals with both PUT and PATCHing
+ * of the metadata for a binary file.
  *
- * @author Andrea Di Cesare {@literal <andrea@softinstigate.com>}
+ * @author Nath Papadacis {@literal <nath@thirststudios.co.uk>}
  */
-public class PatchDocumentHandler extends PipedHttpHandler {
+public class FileMetadataHandler extends PipedHttpHandler {
 
-    private final DocumentDAO documentDAO;
+    private static final String METADATA = "metadata";
+    private static final String FILENAME = "filename";
+
+    private final FileMetadataRepository fileMetadataDAO;
 
     /**
-     * Creates a new instance of PatchDocumentHandler
+     * Creates a new instance of PatchFileMetadataHandler
      */
-    public PatchDocumentHandler() {
-        this(null, new DocumentDAO());
+    public FileMetadataHandler() {
+        this(null, new FileMetadataDAO());
     }
 
-    public PatchDocumentHandler(DocumentDAO documentDAO) {
+    public FileMetadataHandler(FileMetadataRepository fileMetadataDAO) {
         super(null);
-        this.documentDAO = documentDAO;
+        this.fileMetadataDAO = fileMetadataDAO;
     }
 
-    public PatchDocumentHandler(PipedHttpHandler next) {
+    public FileMetadataHandler(PipedHttpHandler next) {
         super(next);
-        this.documentDAO = new DocumentDAO();
+        this.fileMetadataDAO = new FileMetadataDAO();
     }
 
-    public PatchDocumentHandler(PipedHttpHandler next, DocumentDAO documentDAO) {
+    public FileMetadataHandler(PipedHttpHandler next, FileMetadataRepository fileMetadataDAO) {
         super(next);
-        this.documentDAO = documentDAO;
+        this.fileMetadataDAO = fileMetadataDAO;
     }
 
-    /**
-     *
-     * @param exchange
-     * @param context
-     * @throws Exception
-     */
     @Override
     public void handleRequest(
             HttpServerExchange exchange,
@@ -73,10 +76,10 @@ public class PatchDocumentHandler extends PipedHttpHandler {
             next(exchange, context);
             return;
         }
-        
+
         BsonValue _content = context.getContent();
 
-        // cannot PATCH with no data
+        // cannot proceed with no data
         if (_content == null) {
             ResponseHelper.endExchangeWithMessage(
                     exchange,
@@ -87,7 +90,7 @@ public class PatchDocumentHandler extends PipedHttpHandler {
             return;
         }
 
-        // cannot PATCH an array
+        // cannot proceed with an array
         if (!_content.isDocument()) {
             ResponseHelper.endExchangeWithMessage(
                     exchange,
@@ -97,7 +100,7 @@ public class PatchDocumentHandler extends PipedHttpHandler {
             next(exchange, context);
             return;
         }
-        
+
         if (_content.asDocument().isEmpty()) {
             ResponseHelper.endExchangeWithMessage(
                     exchange,
@@ -109,6 +112,13 @@ public class PatchDocumentHandler extends PipedHttpHandler {
         }
 
         BsonDocument content = _content.asDocument();
+        if (content.get(METADATA) == null) {
+            content = new BsonDocument(METADATA, content);
+        }
+        final BsonValue filename = content.get(METADATA).asDocument().get(FILENAME);
+        if (filename != null) {
+            content.put(FILENAME, filename);
+        }
 
         BsonValue id = context.getDocumentId();
 
@@ -124,7 +134,7 @@ public class PatchDocumentHandler extends PipedHttpHandler {
             return;
         }
 
-        OperationResult result = documentDAO.upsertDocument(
+        OperationResult result = fileMetadataDAO.updateMetadata(
                 context.getDBName(),
                 context.getCollectionName(),
                 context.getDocumentId(),
@@ -132,7 +142,7 @@ public class PatchDocumentHandler extends PipedHttpHandler {
                 context.getShardKey(),
                 content,
                 context.getETag(),
-                true,
+                context.getMethod() == METHOD.PATCH,
                 context.isETagCheckRequired());
 
         context.setDbOperationResult(result);
@@ -148,12 +158,12 @@ public class PatchDocumentHandler extends PipedHttpHandler {
                     context,
                     HttpStatus.SC_CONFLICT,
                     "The document's ETag must be provided using the '"
-                    + Headers.IF_MATCH
-                    + "' header");
+                            + Headers.IF_MATCH
+                            + "' header");
             next(exchange, context);
             return;
         }
-        
+
         // handle the case of duplicate key error
         if (result.getHttpCode() == HttpStatus.SC_EXPECTATION_FAILED) {
             ResponseHelper.endExchangeWithMessage(

--- a/src/main/java/org/restheart/handlers/files/PutFileHandler.java
+++ b/src/main/java/org/restheart/handlers/files/PutFileHandler.java
@@ -88,7 +88,10 @@ public class PutFileHandler extends PipedHttpHandler {
                                 metadata,
                                 context.getFilePath());
             } else {
-                throw new RuntimeException("error. file data is null");
+                // throw new RuntimeException("error. file data is null");
+                // try to pass to next handler in order to PUT new metadata on existing file.
+                next(exchange, context);
+                return;
             }
         } catch (IOException | RuntimeException t) {
             if (t instanceof MongoWriteException

--- a/src/main/java/org/restheart/handlers/injectors/BodyInjectorHandler.java
+++ b/src/main/java/org/restheart/handlers/injectors/BodyInjectorHandler.java
@@ -1,17 +1,17 @@
 /*
  * RESTHeart - the Web API for MongoDB
  * Copyright (C) SoftInstigate Srl
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -413,6 +413,8 @@ public class BodyInjectorHandler extends PipedHttpHandler {
             } else {
                 content = null;
             }
+        } else if (contentType == null) {
+            content = null;
         } else {
             ResponseHelper.endExchangeWithMessage(
                     exchange,

--- a/src/main/java/org/restheart/handlers/metadata/AfterWriteCheckMetadataHandler.java
+++ b/src/main/java/org/restheart/handlers/metadata/AfterWriteCheckMetadataHandler.java
@@ -1,17 +1,17 @@
 /*
  * RESTHeart - the Web API for MongoDB
  * Copyright (C) SoftInstigate Srl
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -91,7 +91,8 @@ public class AfterWriteCheckMetadataHandler
                             oldData.get("_id"),
                             context.getShardKey(),
                             oldData,
-                            newEtag);
+                            newEtag,
+                            "_etag");
 
                     // add to response old etag
                     if (oldData.get("$set") != null

--- a/src/test/java/org/restheart/handlers/injectors/BodyInjectorHandlerTest.java
+++ b/src/test/java/org/restheart/handlers/injectors/BodyInjectorHandlerTest.java
@@ -1,26 +1,30 @@
 /*
  * RESTHeart - the Web API for MongoDB
  * Copyright (C) SoftInstigate Srl
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
  * published by the Free Software Foundation, either version 3 of the
  * License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.restheart.handlers.injectors;
 
+import static org.junit.Assert.assertEquals;
 import io.undertow.server.handlers.form.FormData;
+
+import java.lang.reflect.Field;
+
 import org.bson.BsonDocument;
-import static org.junit.Assert.*;
 import org.junit.Test;
+import org.restheart.handlers.PipedHttpHandler;
 
 /**
  *
@@ -33,13 +37,20 @@ public class BodyInjectorHandlerTest {
 
     /**
      * If formData contains a PROPERTIES part, then must be valid JSON
+     * @throws SecurityException
+     * @throws NoSuchFieldException
+     * @throws IllegalAccessException
+     * @throws IllegalArgumentException
      */
     @Test
-    public void test_extractProperties() {
+    public void test_extractProperties() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
         final String jsonString
                 = "{\"key1\": \"value1\", \"key2\": \"value2\"}";
         FormData formData = new FormData(1);
-        formData.add(BodyInjectorHandler.PROPERTIES, jsonString);
+        Field field = PipedHttpHandler.class.getDeclaredField("PROPERTIES");
+        field.setAccessible(true);
+
+        formData.add(field.get(null).toString(), jsonString);
         BsonDocument result = BodyInjectorHandler.extractMetadata(formData);
         BsonDocument expected = BsonDocument.parse(jsonString);
         assertEquals(expected, result);


### PR DESCRIPTION
Although GridFS will treat binary data as immutable the metadata stored in the files collection can still be changed. This was raised under https://softinstigate.atlassian.net/browse/RH-64 as first encountered in issue https://github.com/SoftInstigate/restheart/issues/60

Support for this has been added for both PUT and PATCH. The new code is triggered by:

- Sending a PATCH request with Content-Type of application/[hal+]json to an endpoint of type FILE
- Sending a PUT request with Content-Type of application/[hal+]json to an endpoint of type FILE

The body of the request can be any of:
 - `{ metadata: { keys: values } }`
 - `{ properties: { keys: values } }`
 - `{ keys: values }`

Whichever is submitted, it will be stored in the `metadata` document. In addition:
- Filename updates (values for a key of `filename`) will be propagated to the parent document.
- `_id` present in the metadata will be removed

In order to support PATCHing of existing metadata DAOUtils now supports a method to flatten nested BsonDocuments using dot notation. Although this is currently only used when updating file metadata it might be a useful addition for PATCHing other documents too.

**Notes:** 
1. Bulk operations are not supported for metadata updates.
1. Upserting is disabled for metadata updates (doesn't make sense)
1. `contentType` determined during binary file POST/PUT is stored in the metadata, as a result it will be lost when PUTting a new metadata document unless explicitly added. No attempt is made to keep this. A consideration might be to move this field up to the main document level.
