### PR TITLE
Dropwizard metrics support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ The leading REST API Server for MongoDB, created by [SoftInstigate](http://www.s
 [![Build Status](https://travis-ci.org/SoftInstigate/restheart.svg?branch=master)](https://travis-ci.org/SoftInstigate/restheart)
 [![Dependency Status](https://www.versioneye.com/user/projects/5990d43d6725bd166bb6db81/badge.svg?style=flat-square)](https://www.versioneye.com/user/projects/5990d43d6725bd166bb6db81)
 [![Join the chat at https://gitter.im/SoftInstigate/restheart](https://badges.gitter.im/SoftInstigate/restheart.svg)](https://gitter.im/SoftInstigate/restheart?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Docker Build Statu](https://img.shields.io/docker/build/jrottenberg/ffmpeg.svg)](https://hub.docker.com/r/softinstigate/restheart/)
-[![Docker Stars](https://img.shields.io/docker/stars/softinstigate/restheart.svg?maxAge=2592000)](https://hub.docker.com/r/softinstigate/restheart/) [![Docker Pulls](https://img.shields.io/docker/pulls/softinstigate/restheart.svg?maxAge=2592000)](https://hub.docker.com/r/softinstigate/restheart/)
+[![Docker Stars](https://img.shields.io/docker/stars/softinstigate/restheart.svg?maxAge=2592000)](https://hub.docker.com/r/softinstigate/restheart/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/softinstigate/restheart.svg?maxAge=2592000)](https://hub.docker.com/r/softinstigate/restheart/)
 
 Table of Contents
 --

--- a/etc/restheart-dev.yml
+++ b/etc/restheart-dev.yml
@@ -214,6 +214,8 @@ auth-token-ttl: 15
 # log-file-path: to specify the log file path (default value: restheart.log in system temporary directory)
 # log-level: to set the log level. Value can be OFF, ERROR, WARN, INFO, DEBUG, TRACE and ALL. (default value is INFO)
 # requests-log-level: log the request-response. 0 => no log, 1 => light log, 2 => detailed dump
+# metrics-gathering-level: metrics gathering for which level? OFF => no gathering, ROOT => gathering at root level,
+#                          DATABASE => at db level, COLLECTION => at collection level
 # WARNING: use requests-log-level level 2 only for development purposes, it logs user credentials (Authorization and Auth-Token headers)
 
 enable-log-file: true
@@ -221,6 +223,7 @@ log-file-path: /tmp/restheart.log
 enable-log-console: true
 log-level: DEBUG
 requests-log-level: 1
+metrics-gathering-level: DATABASE
 
 #### ETag policy
 

--- a/pom.xml
+++ b/pom.xml
@@ -176,24 +176,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-json</artifactId>
-            <version>3.2.3</version>
-        </dependency>
-
-        <!--temporary dependency, just to test metrics and JSON output -->
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>2.9.1</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.9.1</version>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,7 @@
                                     <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                                 </manifest>
                             </archive>
+                            <tarLongFileMode>posix</tarLongFileMode>
                         </configuration>
                     </execution>
                     <execution>
@@ -280,6 +281,7 @@
                                 <descriptor>assembly.xml</descriptor>
                             </descriptors>
                             <attach>true</attach>
+                            <tarLongFileMode>posix</tarLongFileMode>
                         </configuration>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,30 @@
         </dependency>
 
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>3.2.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-json</artifactId>
+            <version>3.2.3</version>
+        </dependency>
+
+        <!--temporary dependency, just to test metrics and JSON output -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.9.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>

--- a/src/main/java/org/restheart/Bootstrapper.java
+++ b/src/main/java/org/restheart/Bootstrapper.java
@@ -69,7 +69,7 @@ import org.restheart.handlers.OptionsHandler;
 import org.restheart.handlers.PipedHttpHandler;
 import org.restheart.handlers.PipedWrappingHandler;
 import org.restheart.handlers.RequestContext;
-import org.restheart.handlers.RequestDispacherHandler;
+import org.restheart.handlers.RequestDispatcherHandler;
 import org.restheart.handlers.RequestLoggerHandler;
 import org.restheart.handlers.applicationlogic.ApplicationLogicHandler;
 import org.restheart.handlers.injectors.AccountInjectorHandler;
@@ -749,7 +749,7 @@ public class Bootstrapper {
                 = new AccountInjectorHandler(
                         new DbPropsInjectorHandler(
                                 new CollectionPropsInjectorHandler(
-                                        new RequestDispacherHandler()
+                                        new RequestDispatcherHandler()
                                 )));
 
         PathHandler paths = path();

--- a/src/main/java/org/restheart/Configuration.java
+++ b/src/main/java/org/restheart/Configuration.java
@@ -486,6 +486,12 @@ public class Configuration {
     public static final String LOG_REQUESTS_LEVEL_KEY = "requests-log-level";
 
     /**
+     *  Set metrics gathering level (can be ALL, COLLECTION, DATABASE, ROOT, OFF), gradually gathering less specific metrics.
+     *  Every level contain the upper level as well.
+     */
+    public static final String METRICS_GATHERING_LEVEL_KEY = "metrics-gathering-level";
+
+    /**
      * The key for enabling the Ansi console (for logging with colors)
      */
     public static final String ANSI_CONSOLE = "ansi-console";
@@ -601,6 +607,7 @@ public class Configuration {
     private final ETAG_CHECK_POLICY docEtagCheckPolicy;
     private final Map<String, Object> connectionOptions;
     private final Integer logExchangeDump;
+    private final METRICS_GATHERING_LEVEL metricsGatheringLevel;
     private final long queryTimeLimit;
     private final long aggregationTimeLimit;
     private final boolean ansiConsole;
@@ -705,6 +712,7 @@ public class Configuration {
         docEtagCheckPolicy = DEFAULT_DOC_ETAG_CHECK_POLICY;
 
         logExchangeDump = 0;
+        metricsGatheringLevel = METRICS_GATHERING_LEVEL.ROOT;
 
         connectionOptions = Maps.newHashMap();
     }
@@ -922,13 +930,23 @@ public class Configuration {
         }
 
         logExchangeDump = getAsIntegerOrDefault(conf, LOG_REQUESTS_LEVEL_KEY, 0);
+        {
+            METRICS_GATHERING_LEVEL mglevel;
+            try {
+                String value = getAsStringOrDefault(conf, METRICS_GATHERING_LEVEL_KEY, "ROOT");
+                mglevel = METRICS_GATHERING_LEVEL.valueOf(value.toUpperCase());
+            } catch (IllegalArgumentException iae) {
+                mglevel = METRICS_GATHERING_LEVEL.ROOT;
+            }
+            metricsGatheringLevel = mglevel;
+        }
 
         connectionOptions = getAsMap(conf, CONNECTION_OPTIONS_KEY);
     }
 
     @Override
     public String toString() {
-        return "Configuration{" + "silent=" + silent + ", httpsListener=" + httpsListener + ", httpsPort=" + httpsPort + ", httpsHost=" + httpsHost + ", httpListener=" + httpListener + ", httpPort=" + httpPort + ", httpHost=" + httpHost + ", ajpListener=" + ajpListener + ", ajpPort=" + ajpPort + ", ajpHost=" + ajpHost + ", instanceName=" + instanceName + ", defaultRepresentationFromat=" + defaultRepresentationFromat + ", useEmbeddedKeystore=" + useEmbeddedKeystore + ", keystoreFile=" + keystoreFile + ", keystorePassword=" + keystorePassword + ", certPassword=" + certPassword + ", mongoUri=" + mongoUri + ", mongoMounts=" + mongoMounts + ", staticResourcesMounts=" + staticResourcesMounts + ", applicationLogicMounts=" + applicationLogicMounts + ", metadataNamedSingletons=" + metadataNamedSingletons + ", idmImpl=" + idmImpl + ", idmArgs=" + idmArgs + ", authMechanismImpl=" + authMechanismImpl + ", authMechanismArgs=" + authMechanismArgs + ", amImpl=" + amImpl + ", amArgs=" + amArgs + ", logFilePath=" + logFilePath + ", logLevel=" + logLevel + ", logToConsole=" + logToConsole + ", logToFile=" + logToFile + ", localCacheEnabled=" + localCacheEnabled + ", localCacheTtl=" + localCacheTtl + ", schemaCacheEnabled=" + schemaCacheEnabled + ", schemaCacheTtl=" + schemaCacheTtl + ", requestsLimit=" + requestsLimit + ", ioThreads=" + ioThreads + ", workerThreads=" + workerThreads + ", bufferSize=" + bufferSize + ", buffersPerRegion=" + buffersPerRegion + ", directBuffers=" + directBuffers + ", forceGzipEncoding=" + forceGzipEncoding + ", eagerPoolSize=" + eagerPoolSize + ", eagerLinearSliceWidht=" + eagerLinearSliceWidht + ", eagerLinearSliceDelta=" + eagerLinearSliceDelta + ", eagerLinearSliceHeights=" + Arrays.toString(eagerLinearSliceHeights) + ", eagerRndSliceMinWidht=" + eagerRndSliceMinWidht + ", eagerRndMaxCursors=" + eagerRndMaxCursors + ", authTokenEnabled=" + authTokenEnabled + ", authTokenTtl=" + authTokenTtl + ", dbEtagCheckPolicy=" + dbEtagCheckPolicy + ", collEtagCheckPolicy=" + collEtagCheckPolicy + ", docEtagCheckPolicy=" + docEtagCheckPolicy + ", connectionOptions=" + connectionOptions + ", logExchangeDump=" + logExchangeDump + ", queryTimeLimit=" + queryTimeLimit + ", aggregationTimeLimit=" + aggregationTimeLimit + ", ansiConsole=" + ansiConsole + '}';
+        return "Configuration{" + "silent=" + silent + ", httpsListener=" + httpsListener + ", httpsPort=" + httpsPort + ", httpsHost=" + httpsHost + ", httpListener=" + httpListener + ", httpPort=" + httpPort + ", httpHost=" + httpHost + ", ajpListener=" + ajpListener + ", ajpPort=" + ajpPort + ", ajpHost=" + ajpHost + ", instanceName=" + instanceName + ", defaultRepresentationFromat=" + defaultRepresentationFromat + ", useEmbeddedKeystore=" + useEmbeddedKeystore + ", keystoreFile=" + keystoreFile + ", keystorePassword=" + keystorePassword + ", certPassword=" + certPassword + ", mongoUri=" + mongoUri + ", mongoMounts=" + mongoMounts + ", staticResourcesMounts=" + staticResourcesMounts + ", applicationLogicMounts=" + applicationLogicMounts + ", metadataNamedSingletons=" + metadataNamedSingletons + ", idmImpl=" + idmImpl + ", idmArgs=" + idmArgs + ", authMechanismImpl=" + authMechanismImpl + ", authMechanismArgs=" + authMechanismArgs + ", amImpl=" + amImpl + ", amArgs=" + amArgs + ", logFilePath=" + logFilePath + ", logLevel=" + logLevel + ", logToConsole=" + logToConsole + ", logToFile=" + logToFile + ", localCacheEnabled=" + localCacheEnabled + ", localCacheTtl=" + localCacheTtl + ", schemaCacheEnabled=" + schemaCacheEnabled + ", schemaCacheTtl=" + schemaCacheTtl + ", requestsLimit=" + requestsLimit + ", ioThreads=" + ioThreads + ", workerThreads=" + workerThreads + ", bufferSize=" + bufferSize + ", buffersPerRegion=" + buffersPerRegion + ", directBuffers=" + directBuffers + ", forceGzipEncoding=" + forceGzipEncoding + ", eagerPoolSize=" + eagerPoolSize + ", eagerLinearSliceWidht=" + eagerLinearSliceWidht + ", eagerLinearSliceDelta=" + eagerLinearSliceDelta + ", eagerLinearSliceHeights=" + Arrays.toString(eagerLinearSliceHeights) + ", eagerRndSliceMinWidht=" + eagerRndSliceMinWidht + ", eagerRndMaxCursors=" + eagerRndMaxCursors + ", authTokenEnabled=" + authTokenEnabled + ", authTokenTtl=" + authTokenTtl + ", dbEtagCheckPolicy=" + dbEtagCheckPolicy + ", collEtagCheckPolicy=" + collEtagCheckPolicy + ", docEtagCheckPolicy=" + docEtagCheckPolicy + ", connectionOptions=" + connectionOptions + ", logExchangeDump=" + logExchangeDump + ", metricsGatheringLevel=" + metricsGatheringLevel + ", queryTimeLimit=" + queryTimeLimit + ", aggregationTimeLimit=" + aggregationTimeLimit + ", ansiConsole=" + ansiConsole + '}';
     }
 
     /**
@@ -1568,5 +1586,28 @@ public class Configuration {
      */
     public REPRESENTATION_FORMAT getDefaultRepresentationFormat() {
         return defaultRepresentationFromat;
+    }
+
+    /**
+     * @return the level of metrics that will be collected (and above)
+     */
+    public METRICS_GATHERING_LEVEL getMetricsGatheringLevel() {
+        return metricsGatheringLevel;
+    }
+
+    /** decides whether metrics are gathered at the given log level or not*/
+    public boolean gatheringAboveOrEqualToLevel(METRICS_GATHERING_LEVEL level) {
+        return getMetricsGatheringLevel().compareTo(level) >= 0;
+    }
+
+    public enum METRICS_GATHERING_LEVEL {
+        /**do not gather any metrics*/
+        OFF,
+        /**gather basic metrics (for all databases, but not specific per database)*/
+        ROOT,
+        /**gather basic metrics, and also specific per database (but not collection-specific)*/
+        DATABASE,
+        /**gather basic, database, and collection-specific metrics*/
+        COLLECTION
     }
 }

--- a/src/main/java/org/restheart/handlers/MetricsInstrumentationHandler.java
+++ b/src/main/java/org/restheart/handlers/MetricsInstrumentationHandler.java
@@ -1,0 +1,82 @@
+package org.restheart.handlers;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import com.codahale.metrics.MetricRegistry;
+
+import org.restheart.Bootstrapper;
+import org.restheart.Configuration;
+import org.restheart.utils.SharedMetricRegistryProxy;
+
+import java.util.concurrent.TimeUnit;
+
+import io.undertow.server.HttpServerExchange;
+
+import static org.restheart.Configuration.METRICS_GATHERING_LEVEL.COLLECTION;
+import static org.restheart.Configuration.METRICS_GATHERING_LEVEL.DATABASE;
+import static org.restheart.Configuration.METRICS_GATHERING_LEVEL.ROOT;
+
+/**
+ * Handler to measure calls to restheart.
+ * Will only take actions if metrics should be gathered (config option "metrics-gathering-level" > OFF)
+ */
+public class MetricsInstrumentationHandler extends PipedHttpHandler {
+
+    public MetricsInstrumentationHandler(PipedHttpHandler next) {
+        super(next);
+    }
+
+    /**Writable in unit tests to make testing easier*/
+    @VisibleForTesting
+    Configuration configuration = Bootstrapper.getConfiguration();
+
+    @VisibleForTesting
+    SharedMetricRegistryProxy metrics = new SharedMetricRegistryProxy();
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange, RequestContext context) throws Exception {
+        final long requestStartTime = context.getRequestStartTime();
+
+        exchange.addExchangeCompleteListener((httpServerExchange, nextListener) -> {
+            addMetrics(requestStartTime, exchange, context);
+
+            nextListener.proceed();
+        });
+
+        if (!exchange.isResponseComplete() && getNext() != null) {
+            next(exchange, context);
+        }
+    }
+
+    private void addDefaultMetrics(MetricRegistry registry, long duration, HttpServerExchange exchange, RequestContext context) {
+        registry.timer(context.getType().toString() + "." + context.getMethod().toString())
+            .update(duration, TimeUnit.MILLISECONDS);
+        registry.timer(context.getType().toString() + "." + context.getMethod().toString() + "." + exchange.getStatusCode())
+            .update(duration, TimeUnit.MILLISECONDS);
+        registry.timer(context.getType().toString() + "." + context.getMethod().toString() + "." + (exchange.getStatusCode() / 100) + "xx")
+            .update(duration, TimeUnit.MILLISECONDS);
+    }
+
+    private boolean isFilledAndNotMetrics(String dbOrCollectionName) {
+        return dbOrCollectionName != null && !dbOrCollectionName.equalsIgnoreCase(RequestContext._METRICS);
+    }
+
+    private void addMetrics(long startTime, HttpServerExchange exchange, RequestContext context) {
+        if (configuration.gatheringAboveOrEqualToLevel(ROOT)) {
+            long endTime = System.currentTimeMillis();
+            long duration = endTime - startTime;
+
+            addDefaultMetrics(metrics.registry(), duration, exchange, context);
+
+            if (isFilledAndNotMetrics(context.getDBName()) && configuration.gatheringAboveOrEqualToLevel(DATABASE)) {
+                final MetricRegistry dbRegistry = metrics.registry(context.getDBName());
+                addDefaultMetrics(dbRegistry, duration, exchange, context);
+
+                if (isFilledAndNotMetrics(context.getCollectionName()) && configuration.gatheringAboveOrEqualToLevel(COLLECTION)) {
+                    final MetricRegistry collectionRegistry = metrics.registry(context.getDBName(), context.getCollectionName());
+                    addDefaultMetrics(collectionRegistry, duration, exchange, context);
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/restheart/handlers/MetricsInstrumentationHandler.java
+++ b/src/main/java/org/restheart/handlers/MetricsInstrumentationHandler.java
@@ -6,6 +6,7 @@ import com.codahale.metrics.MetricRegistry;
 
 import org.restheart.Bootstrapper;
 import org.restheart.Configuration;
+import org.restheart.db.DbsDAO;
 import org.restheart.utils.SharedMetricRegistryProxy;
 
 import java.util.concurrent.TimeUnit;
@@ -24,6 +25,11 @@ public class MetricsInstrumentationHandler extends PipedHttpHandler {
 
     public MetricsInstrumentationHandler(PipedHttpHandler next) {
         super(next);
+    }
+
+    @VisibleForTesting
+    MetricsInstrumentationHandler(PipedHttpHandler next, DbsDAO dbsDAO) {
+        super(next, dbsDAO);
     }
 
     /**Writable in unit tests to make testing easier*/
@@ -57,11 +63,15 @@ public class MetricsInstrumentationHandler extends PipedHttpHandler {
             .update(duration, TimeUnit.MILLISECONDS);
     }
 
-    private boolean isFilledAndNotMetrics(String dbOrCollectionName) {
-        return dbOrCollectionName != null && !dbOrCollectionName.equalsIgnoreCase(RequestContext._METRICS);
+    @VisibleForTesting
+    static boolean isFilledAndNotMetrics(String dbOrCollectionName) {
+        return dbOrCollectionName != null
+               && !dbOrCollectionName.trim().isEmpty()
+               && !dbOrCollectionName.equalsIgnoreCase(RequestContext._METRICS);
     }
 
-    private void addMetrics(long startTime, HttpServerExchange exchange, RequestContext context) {
+    @VisibleForTesting
+    void addMetrics(long startTime, HttpServerExchange exchange, RequestContext context) {
         if (configuration.gatheringAboveOrEqualToLevel(ROOT)) {
             long endTime = System.currentTimeMillis();
             long duration = endTime - startTime;

--- a/src/main/java/org/restheart/handlers/RequestDispatcherHandler.java
+++ b/src/main/java/org/restheart/handlers/RequestDispatcherHandler.java
@@ -71,9 +71,9 @@ import org.slf4j.LoggerFactory;
  *
  * @author Andrea Di Cesare {@literal <andrea@softinstigate.com>}
  */
-public final class RequestDispacherHandler extends PipedHttpHandler {
+public final class RequestDispatcherHandler extends PipedHttpHandler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(RequestDispacherHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RequestDispatcherHandler.class);
 
     private final Map<TYPE, Map<METHOD, PipedHttpHandler>> handlersMultimap;
 
@@ -83,7 +83,7 @@ public final class RequestDispacherHandler extends PipedHttpHandler {
     /**
      * Creates a new instance of RequestDispacherHandler
      */
-    public RequestDispacherHandler() {
+    public RequestDispatcherHandler() {
         this(true);
     }
 
@@ -93,7 +93,7 @@ public final class RequestDispacherHandler extends PipedHttpHandler {
      *
      * @param initialize if false then do not initialize the handlersMultimap
      */
-    RequestDispacherHandler(boolean initialize) {
+    RequestDispatcherHandler(boolean initialize) {
         super(null, null);
         this.handlersMultimap = new HashMap<>();
         if (initialize) {
@@ -442,7 +442,7 @@ public final class RequestDispacherHandler extends PipedHttpHandler {
                     exchange,
                     context,
                     HttpStatus.SC_METHOD_NOT_ALLOWED,
-                    "mentod " + context.getMethod().name() + " not allowed");
+                    "method " + context.getMethod().name() + " not allowed");
             responseSenderHandler.handleRequest(exchange, context);
             return;
         }
@@ -475,7 +475,7 @@ public final class RequestDispacherHandler extends PipedHttpHandler {
                     exchange,
                     context,
                     HttpStatus.SC_METHOD_NOT_ALLOWED,
-                    "mentod " + context.getMethod().name() + " not allowed");
+                    "method " + context.getMethod().name() + " not allowed");
             responseSenderHandler.handleRequest(exchange, context);
         }
     }

--- a/src/main/java/org/restheart/handlers/RequestDispatcherHandler.java
+++ b/src/main/java/org/restheart/handlers/RequestDispatcherHandler.java
@@ -24,6 +24,7 @@ import org.restheart.handlers.RequestContext.METHOD;
 import org.restheart.handlers.RequestContext.TYPE;
 import org.restheart.handlers.aggregation.AggregationTransformer;
 import org.restheart.handlers.aggregation.GetAggregationHandler;
+import org.restheart.handlers.applicationlogic.MetricsHandler;
 import org.restheart.handlers.bulk.BulkDeleteDocumentsHandler;
 import org.restheart.handlers.bulk.BulkPatchDocumentsHandler;
 import org.restheart.handlers.bulk.BulkPostCollectionHandler;
@@ -342,6 +343,9 @@ public final class RequestDispatcherHandler extends PipedHttpHandler {
                 new RequestTransformerMetadataHandler(
                         new DeleteDocumentHandler(
                                 respTransformers())));
+
+
+        putPipedHttpHandler(TYPE.METRICS, METHOD.GET, new MetricsHandler(respTransformers()));
     }
 
     private PipedHttpHandler respTransformers() {

--- a/src/main/java/org/restheart/handlers/RequestLoggerHandler.java
+++ b/src/main/java/org/restheart/handlers/RequestLoggerHandler.java
@@ -103,7 +103,7 @@ public class RequestLoggerHandler extends PipedHttpHandler {
         }
 
         final StringBuilder sb = new StringBuilder();
-        final long start = context.getRequestStartTime();
+        final long start = context != null ? context.getRequestStartTime() : System.currentTimeMillis();
 
         if (logLevel == 1) {
             sb.append(exchange.getRequestMethod()).append(" ")

--- a/src/main/java/org/restheart/handlers/RequestLoggerHandler.java
+++ b/src/main/java/org/restheart/handlers/RequestLoggerHandler.java
@@ -77,7 +77,7 @@ public class RequestLoggerHandler extends PipedHttpHandler {
     @Override
     public void handleRequest(HttpServerExchange exchange, RequestContext context) throws Exception {
         if (configuration.logExchangeDump() > 0) {
-            dumpExchange(exchange, configuration.logExchangeDump());
+            dumpExchange(exchange, context, configuration.logExchangeDump());
         }
 
         if (getNext() != null) {
@@ -97,13 +97,13 @@ public class RequestLoggerHandler extends PipedHttpHandler {
      * @param exchange the HttpServerExchange
      * @param logLevel it can be 0, 1 or 2
      */
-    protected void dumpExchange(HttpServerExchange exchange, Integer logLevel) {
+    protected void dumpExchange(HttpServerExchange exchange, RequestContext context,  Integer logLevel) {
         if (logLevel < 1) {
             return;
         }
 
         final StringBuilder sb = new StringBuilder();
-        final long start = System.currentTimeMillis();
+        final long start = context.getRequestStartTime();
 
         if (logLevel == 1) {
             sb.append(exchange.getRequestMethod()).append(" ")

--- a/src/main/java/org/restheart/handlers/applicationlogic/MetricsHandler.java
+++ b/src/main/java/org/restheart/handlers/applicationlogic/MetricsHandler.java
@@ -1,0 +1,195 @@
+/*
+ * RESTHeart - the Web API for MongoDB
+ * Copyright (C) SoftInstigate Srl
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.restheart.handlers.applicationlogic;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.json.MetricsModule;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import org.restheart.Bootstrapper;
+import org.restheart.Configuration;
+import org.restheart.handlers.PipedHttpHandler;
+import org.restheart.handlers.RequestContext;
+import org.restheart.handlers.RequestContext.METHOD;
+import org.restheart.utils.HttpStatus;
+import org.restheart.utils.ResponseHelper;
+import org.restheart.utils.SharedMetricRegistryProxy;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+
+import static org.restheart.Configuration.METRICS_GATHERING_LEVEL.COLLECTION;
+import static org.restheart.Configuration.METRICS_GATHERING_LEVEL.DATABASE;
+import static org.restheart.Configuration.METRICS_GATHERING_LEVEL.ROOT;
+
+/**
+ * A handler for dropwizard.io metrics that can return both default metrics JSON and the prometheus format.
+ *
+ * @author Lena Brüder {@literal <brueder@e-spirit.com>}
+ */
+public class MetricsHandler extends PipedHttpHandler {
+
+    private enum ResponseType {
+        JSON("application/json") {
+            @Override
+            public String generateResponse(MetricRegistry registry) throws IOException {
+                ObjectMapper mapper = new ObjectMapper();
+                MetricsModule metricsModule = new MetricsModule(TimeUnit.SECONDS, TimeUnit.MILLISECONDS, false);
+                mapper.registerModule(metricsModule);
+
+                ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();
+                StringWriter stringWriter = new StringWriter();
+                writer.writeValue(stringWriter, registry);
+                return stringWriter.toString();
+            }
+        },
+        PROMETHEUS("text/plain") { //TODO: which content type to use for this format?
+            @Override
+            public String generateResponse(MetricRegistry registry) throws IOException {
+                ObjectMapper mapper = new ObjectMapper();
+                MetricsModule metricsModule = new MetricsModule(TimeUnit.SECONDS, TimeUnit.MILLISECONDS, false);
+                mapper.registerModule(metricsModule);
+
+                StringBuilder sb = new StringBuilder();
+
+                JsonNode rootNode = mapper.valueToTree(registry);
+                Iterator<Map.Entry<String, JsonNode>> rootIt = rootNode.path("timers").fields();
+                while (rootIt.hasNext()) {
+                    Map.Entry<String, JsonNode> rootEntry = rootIt.next();
+                    String key = rootEntry.getKey();
+                    final String[] split = key.split("\\.");
+                    final String type = split[0];
+                    final String method = split[1];
+                    final String responseCode = split.length >= 3 ? split[2] : null;
+
+                    String metricType;
+                    Iterator<Map.Entry<String, JsonNode>> metricTypeIt = rootEntry.getValue().fields();
+                    while (metricTypeIt.hasNext()) {
+                        Map.Entry<String, JsonNode> metricTypeEntry = metricTypeIt.next();
+                        metricType = metricTypeEntry.getKey();
+                        String value = metricTypeEntry.getValue().asText();
+                        sb.append("http_response_timer_" + type + "_" + metricType);
+                        sb.append("{");
+                        sb.append("method=\"" + method + "\"");
+                        if (responseCode != null) {
+                            sb.append(",");
+                            sb.append("code=\"" + responseCode + "\"");
+                        }
+                        sb.append("}");
+                        sb.append("=" + value);
+                        sb.append("\n");
+                    }
+                }
+
+
+                return sb.toString();
+            }
+        };
+
+        String contentType;
+        abstract public String generateResponse(MetricRegistry registry) throws IOException;
+
+        ResponseType(String contentType) {
+            this.contentType = contentType;
+        }
+
+        public static ResponseType forAcceptHeader(String acceptHeader) {
+            return (acceptHeader != null && acceptHeader.contains(JSON.contentType)) ? JSON : PROMETHEUS;    //TODO: parse accept header correctly!
+        }
+    }
+
+    @VisibleForTesting
+    Configuration configuration = Bootstrapper.getConfiguration();
+
+    @VisibleForTesting
+    SharedMetricRegistryProxy metrics = new SharedMetricRegistryProxy();
+
+    public MetricsHandler(PipedHttpHandler next) {
+        super(next);
+    }
+
+    private boolean isFilledAndNotMetrics(String dbOrCollectionName) {
+        return dbOrCollectionName != null && !dbOrCollectionName.equalsIgnoreCase(RequestContext._METRICS);
+    }
+
+    /**
+     * Finds the metric registry that is related to the request path currently being asked for.
+     * Will only write metrics in case they have been gathered - if none are there, will return null.
+     * @return a metric registry, or null if none match
+     */
+    private MetricRegistry getCorrectMetricRegistry(RequestContext context) {
+        MetricRegistry registry = null;
+        if (configuration.gatheringAboveOrEqualToLevel(ROOT)) {
+            if (isFilledAndNotMetrics(context.getDBName())) {
+                if (isFilledAndNotMetrics(context.getCollectionName())) {
+                    if (configuration.gatheringAboveOrEqualToLevel(COLLECTION)) {
+                        registry = metrics.registry(context.getDBName(), context.getCollectionName());
+                    }
+                } else {
+                    if (configuration.gatheringAboveOrEqualToLevel(DATABASE)) {
+                        registry = metrics.registry(context.getDBName());
+                    }
+                }
+            } else {
+                registry = metrics.registry();
+            }
+        }
+        return registry;
+    }
+
+    /**
+     *
+     * @param exchange
+     * @param context
+     * @throws Exception
+     */
+    @Override
+    public void handleRequest(HttpServerExchange exchange, RequestContext context) throws Exception {
+        MetricRegistry registry = getCorrectMetricRegistry(context);
+
+        if (registry != null) {
+            if (context.getMethod() == METHOD.GET) {
+                exchange.setStatusCode(HttpStatus.SC_OK);
+                exchange.getResponseSender().send(
+                    ResponseType.forAcceptHeader(exchange.getRequestHeaders().getFirst(Headers.ACCEPT))
+                        .generateResponse(registry)
+                );
+                exchange.endExchange();
+            } else {
+                exchange.setStatusCode(HttpStatus.SC_OK);
+                if (context.getContent() != null) {
+                    exchange.getResponseSender().send(context.getContent().toString());
+                }
+                exchange.endExchange();
+            }
+        } else {  //no matching registry found
+            ResponseHelper.endExchangeWithMessage(exchange, context, HttpStatus.SC_NOT_FOUND, "not found");
+            next(exchange, context);
+        }
+    }
+}

--- a/src/main/java/org/restheart/handlers/applicationlogic/MetricsHandler.java
+++ b/src/main/java/org/restheart/handlers/applicationlogic/MetricsHandler.java
@@ -23,7 +23,10 @@ import com.codahale.metrics.MetricRegistry;
 
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
+import org.bson.json.Converter;
+import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
+import org.bson.json.StrictJsonWriter;
 import org.restheart.Bootstrapper;
 import org.restheart.Configuration;
 import org.restheart.handlers.PipedHttpHandler;
@@ -64,7 +67,9 @@ public class MetricsHandler extends PipedHttpHandler {
             @Override
             public String generateResponse(MetricRegistry registry) throws IOException {
                 BsonDocument document = MetricsJsonGenerator.generateMetricsBson(registry, TimeUnit.SECONDS, TimeUnit.MILLISECONDS);
-                return document.toJson(JsonWriterSettings.builder().indent(true).build());
+                return document.toJson(
+                    JsonWriterSettings.builder().outputMode(JsonMode.RELAXED).indent(true).build()
+                );
             }
         },
         /**format description can be found at https://prometheus.io/docs/instrumenting/exposition_formats/ */

--- a/src/main/java/org/restheart/handlers/injectors/RequestContextInjectorHandler.java
+++ b/src/main/java/org/restheart/handlers/injectors/RequestContextInjectorHandler.java
@@ -119,7 +119,7 @@ public class RequestContextInjectorHandler extends PipedHttpHandler {
                 try {
                     rep = REPRESENTATION_FORMAT.valueOf(_rep.trim().toUpperCase());
                 } catch (IllegalArgumentException iae) {
-                    rcontext.addWarning("illegal rep paramenter " + _rep + " (must be PLAIN_JSON, PJ or HAL)");
+                    rcontext.addWarning("illegal rep parameter " + _rep + " (must be PLAIN_JSON, PJ or HAL)");
                 }
             }
         }

--- a/src/main/java/org/restheart/utils/MetricsJsonGenerator.java
+++ b/src/main/java/org/restheart/utils/MetricsJsonGenerator.java
@@ -1,0 +1,165 @@
+package org.restheart.utils;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt64;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.toMap;
+
+/**
+ * Json Generator for the metrics format, follows for output what can be found at
+ * https://github.com/iZettle/dropwizard-metrics/blob/v3.1.2/metrics-json/src/main/java/com/codahale/metrics/json/MetricsModule.java
+ */
+public class MetricsJsonGenerator {
+    private final TimeUnit rateUnit;
+    private final String singularRateUnitString;
+    private final double rateFactor;
+    private final TimeUnit durationUnit;
+    private final double durationFactor;
+    boolean showSamples = false;
+
+    private static String singular(TimeUnit timeUnit) {
+        String unitString = timeUnit.name().toLowerCase(Locale.US);
+        return unitString.substring(0, unitString.length() - 1);
+    }
+
+    private MetricsJsonGenerator(TimeUnit rateUnit, TimeUnit durationUnit) {
+        this.durationUnit = durationUnit;
+        this.durationFactor = 1.0 / durationUnit.toNanos(1);
+        this.rateUnit = rateUnit;
+        this.rateFactor = rateUnit.toSeconds(1);
+        this.singularRateUnitString = singular(rateUnit);
+    }
+
+    private BsonDocument generateTimer(Timer timer) {
+        BsonDocument document = new BsonDocument();
+        final Snapshot snapshot = timer.getSnapshot();
+        document.append("count", new BsonInt64(timer.getCount()));
+        document.append("max", new BsonDouble(snapshot.getMax() * durationFactor));
+        document.append("mean", new BsonDouble(snapshot.getMean() * durationFactor));
+        document.append("min", new BsonDouble(snapshot.getMin() * durationFactor));
+
+        document.append("p50", new BsonDouble(snapshot.getMedian() * durationFactor));
+        document.append("p75", new BsonDouble(snapshot.get75thPercentile() * durationFactor));
+        document.append("p95", new BsonDouble(snapshot.get95thPercentile() * durationFactor));
+        document.append("p98", new BsonDouble(snapshot.get98thPercentile() * durationFactor));
+        document.append("p99", new BsonDouble(snapshot.get99thPercentile() * durationFactor));
+        document.append("p999", new BsonDouble(snapshot.get999thPercentile() * durationFactor));
+
+        if (showSamples) {
+            document.append("values", new BsonArray(
+                Arrays.stream(snapshot.getValues())
+                    .mapToDouble(x -> x * durationFactor)
+                    .mapToObj(BsonDouble::new)
+                    .collect(Collectors.toList())
+            ));
+        }
+
+        document.append("stddev", new BsonDouble(snapshot.getStdDev() * durationFactor));
+        document.append("m15_rate", new BsonDouble(timer.getFifteenMinuteRate() * rateFactor));
+        document.append("m1_rate", new BsonDouble(timer.getOneMinuteRate() * rateFactor));
+        document.append("m5_rate", new BsonDouble(timer.getFiveMinuteRate() * rateFactor));
+        document.append("mean_rate", new BsonDouble(timer.getMeanRate() * rateFactor));
+        document.append("duration_units", new BsonString(durationUnit.name().toLowerCase(Locale.US)));
+        document.append("rate_units", new BsonString("calls/" + singularRateUnitString));
+        return document;
+    }
+
+    private BsonDocument generateCounter(Counter counter) {
+        return new BsonDocument().append("count", new BsonInt64(counter.getCount()));
+    }
+
+    private BsonDocument generateMeter(Meter meter) {
+        BsonDocument document = new BsonDocument();
+
+        document.append("count", new BsonInt64(meter.getCount()));
+        document.append("m15_rate", new BsonDouble(meter.getFifteenMinuteRate() * rateFactor));
+        document.append("m1_rate", new BsonDouble(meter.getOneMinuteRate() * rateFactor));
+        document.append("m5_rate", new BsonDouble(meter.getFiveMinuteRate() * rateFactor));
+        document.append("mean_rate", new BsonDouble(meter.getMeanRate() * rateFactor));
+        document.append("units", new BsonString("calls/" + singularRateUnitString));
+
+        return document;
+    }
+
+    private BsonDocument generateHistogram(Histogram histogram) {
+        BsonDocument document = new BsonDocument();
+        final Snapshot snapshot = histogram.getSnapshot();
+        document.append("count", new BsonInt64(histogram.getCount()));
+        document.append("max", new BsonDouble(snapshot.getMax()));
+        document.append("mean", new BsonDouble(snapshot.getMean()));
+        document.append("min", new BsonDouble(snapshot.getMin()));
+        document.append("p50", new BsonDouble(snapshot.getMedian()));
+        document.append("p75", new BsonDouble(snapshot.get75thPercentile()));
+        document.append("p95", new BsonDouble(snapshot.get95thPercentile()));
+        document.append("p98", new BsonDouble(snapshot.get98thPercentile()));
+        document.append("p99", new BsonDouble(snapshot.get99thPercentile()));
+        document.append("p999", new BsonDouble(snapshot.get999thPercentile()));
+
+        if (showSamples) {
+            document.append("values", new BsonArray(
+                Arrays.stream(snapshot.getValues())
+                    .mapToObj(BsonInt64::new)
+                    .collect(Collectors.toList())
+            ));
+        }
+
+        document.append("stddev", new BsonDouble(snapshot.getStdDev()));
+        return document;
+    }
+
+    private <T> BsonDocument generateGauge(Gauge<T> gauge) {
+        try {
+            T value = gauge.getValue();
+            final BsonValue valueAsBson;
+            if (value instanceof Double) {
+                valueAsBson = new BsonDouble((Double) value);
+            } else if (value instanceof Long) {
+                valueAsBson = new BsonInt64((Long)value);
+            } else { //returning a string is formally wrong here, but the best I can get for all the rest
+                valueAsBson = new BsonString(value.toString());
+            }
+            return new BsonDocument().append("value", valueAsBson);
+        } catch (RuntimeException re) {
+            return new BsonDocument().append("error", new BsonString(re.toString()));
+        }
+    }
+
+    private <T> BsonDocument toBson(Map<String, T> map, Function<T, BsonDocument> f) {
+        Map<String, BsonDocument> collect = map.entrySet().stream()
+            .collect(toMap(Map.Entry::getKey, x -> f.apply(x.getValue())));
+        BsonDocument document = new BsonDocument();
+        document.putAll(collect);
+        return document;
+    }
+
+    public static BsonDocument generateMetricsBson(MetricRegistry registry, TimeUnit rateUnit, TimeUnit durationUnit) {
+        MetricsJsonGenerator generator = new MetricsJsonGenerator(rateUnit, durationUnit);
+
+        return new BsonDocument()
+            .append("version", new BsonString("3.0.0"))
+            .append("gauges", generator.toBson(registry.getGauges(), generator::generateGauge))
+            .append("counters", generator.toBson(registry.getCounters(), generator::generateCounter))
+            .append("histograms", generator.toBson(registry.getHistograms(), generator::generateHistogram))
+            .append("meters", generator.toBson(registry.getMeters(), generator::generateMeter))
+            .append("timers", generator.toBson(registry.getTimers(), generator::generateTimer));
+    }
+}

--- a/src/main/java/org/restheart/utils/MetricsJsonGenerator.java
+++ b/src/main/java/org/restheart/utils/MetricsJsonGenerator.java
@@ -11,6 +11,7 @@ import com.codahale.metrics.Timer;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
 import org.bson.BsonDouble;
+import org.bson.BsonInt32;
 import org.bson.BsonInt64;
 import org.bson.BsonString;
 import org.bson.BsonValue;
@@ -132,8 +133,12 @@ public class MetricsJsonGenerator {
             final BsonValue valueAsBson;
             if (value instanceof Double) {
                 valueAsBson = new BsonDouble((Double) value);
+            } else if (value instanceof Float) {
+                valueAsBson = new BsonDouble((Float)value);
             } else if (value instanceof Long) {
                 valueAsBson = new BsonInt64((Long)value);
+            } else if (value instanceof Integer) {
+                valueAsBson = new BsonInt32((Integer)value);
             } else { //returning a string is formally wrong here, but the best I can get for all the rest
                 valueAsBson = new BsonString(value.toString());
             }

--- a/src/main/java/org/restheart/utils/SharedMetricRegistryProxy.java
+++ b/src/main/java/org/restheart/utils/SharedMetricRegistryProxy.java
@@ -1,0 +1,20 @@
+package org.restheart.utils;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+
+/**
+ * A proxy to the shared metrics registry, mainly to make unit testing easier (extend and inject to object-under-test)
+ */
+public class SharedMetricRegistryProxy {
+    private static final MetricRegistry defaultRegistry = SharedMetricRegistries.getOrCreate("default");
+    public MetricRegistry registry() {
+        return defaultRegistry;
+    }
+    public MetricRegistry registry(String dbName) {
+        return SharedMetricRegistries.getOrCreate(dbName);
+    }
+    public MetricRegistry registry(String dbName, String collectionName) {
+        return SharedMetricRegistries.getOrCreate(dbName + "/" + collectionName);
+    }
+}

--- a/src/test/java/io/undertow/server/HttpServerExchange.java
+++ b/src/test/java/io/undertow/server/HttpServerExchange.java
@@ -75,10 +75,16 @@ public class HttpServerExchange extends AbstractAttachable {
         return this;
     }
 
+    void addExchangeCompleteListener(ExchangeCompletionListener listener) {}
+
     /**
      * @return the statusCode
      */
     public int getResponseCode() {
+        return statusCode;
+    }
+
+    public int getStatusCode() {
         return statusCode;
     }
 

--- a/src/test/java/org/restheart/handlers/MetricsInstrumentationHandlerTest.java
+++ b/src/test/java/org/restheart/handlers/MetricsInstrumentationHandlerTest.java
@@ -1,0 +1,82 @@
+package org.restheart.handlers;
+
+import com.codahale.metrics.MetricRegistry;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.restheart.Configuration;
+import org.restheart.db.MongoDBClientSingleton;
+import org.restheart.utils.SharedMetricRegistryProxy;
+
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.ServerConnection;
+import io.undertow.util.Methods;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class MetricsInstrumentationHandlerTest {
+
+    @Before
+    public void setUp() {
+        MongoDBClientSingleton.init(new Configuration());
+    }
+
+    @Test
+    public void testIfFilledAndNotMetrics() throws Exception {
+        assertTrue(MetricsInstrumentationHandler.isFilledAndNotMetrics("foobar"));
+        assertTrue(MetricsInstrumentationHandler.isFilledAndNotMetrics("rainbow"));
+        assertFalse(MetricsInstrumentationHandler.isFilledAndNotMetrics("_metrics"));
+        assertFalse(MetricsInstrumentationHandler.isFilledAndNotMetrics(""));
+        assertFalse(MetricsInstrumentationHandler.isFilledAndNotMetrics("  "));
+        assertFalse(MetricsInstrumentationHandler.isFilledAndNotMetrics(null));
+    }
+
+    @Test
+    public void testAddMetrics() throws Exception {
+        Configuration config = mock(Configuration.class);
+        when(config.gatheringAboveOrEqualToLevel(Configuration.METRICS_GATHERING_LEVEL.ROOT)).thenReturn(true);
+        when(config.gatheringAboveOrEqualToLevel(Configuration.METRICS_GATHERING_LEVEL.DATABASE)).thenReturn(true);
+        when(config.gatheringAboveOrEqualToLevel(Configuration.METRICS_GATHERING_LEVEL.COLLECTION)).thenReturn(true);
+
+        MetricRegistry registry = new MetricRegistry();
+        MetricRegistry registryDb = new MetricRegistry();
+        MetricRegistry registryColl = new MetricRegistry();
+        SharedMetricRegistryProxy proxy = new SharedMetricRegistryProxy() {
+            @Override
+            public MetricRegistry registry() {
+                return registry;
+            }
+
+            @Override
+            public MetricRegistry registry(String dbName) {
+                return registryDb;
+            }
+
+            @Override
+            public MetricRegistry registry(String dbName, String collectionName) {
+                return registryColl;
+            }
+        };
+
+        MetricsInstrumentationHandler mih = new MetricsInstrumentationHandler(null, null);
+        mih.configuration = config;
+        mih.metrics = proxy;
+
+        HttpServerExchange httpServerExchange = mock(HttpServerExchange.class);
+        when(httpServerExchange.getStatusCode()).thenReturn(200);
+        when(httpServerExchange.getRequestMethod()).thenReturn(Methods.GET);
+        when(httpServerExchange.getRequestPath()).thenReturn("/foo/bar");
+
+        RequestContext requestContext = new RequestContext(httpServerExchange, "/foo", "/bar");
+
+        mih.addMetrics(0, httpServerExchange, requestContext);
+
+        assertEquals(3, registry.getTimers().size());
+        assertEquals(3, registryDb.getTimers().size());
+        assertEquals(3, registryColl.getTimers().size());
+    }
+}

--- a/src/test/java/org/restheart/handlers/RequestDispacherHandlerTest.java
+++ b/src/test/java/org/restheart/handlers/RequestDispacherHandlerTest.java
@@ -50,7 +50,7 @@ public class RequestDispacherHandlerTest {
         }
     };
 
-    private RequestDispacherHandler dispacher;
+    private RequestDispatcherHandler dispacher;
 
     public RequestDispacherHandlerTest() {
     }
@@ -58,7 +58,7 @@ public class RequestDispacherHandlerTest {
     @Before
     public void setUp() {
         MongoDBClientSingleton.init(new Configuration());
-        dispacher = new RequestDispacherHandler(false);
+        dispacher = new RequestDispatcherHandler(false);
     }
 
     @After

--- a/src/test/java/org/restheart/handlers/applicationlogic/MetricsHandlerTest.java
+++ b/src/test/java/org/restheart/handlers/applicationlogic/MetricsHandlerTest.java
@@ -1,0 +1,122 @@
+package org.restheart.handlers.applicationlogic;
+
+import com.codahale.metrics.MetricRegistry;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.restheart.Configuration;
+import org.restheart.handlers.RequestContext;
+import org.restheart.utils.SharedMetricRegistryProxy;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Methods;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MetricsHandlerTest {
+
+    class MyMetricRegistry extends MetricRegistry {
+        String name;
+        MyMetricRegistry(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        handler = new MetricsHandler(null, null);
+        handler.configuration = new Configuration();
+        handler.metrics = new SharedMetricRegistryProxy(){
+            @Override
+            public MetricRegistry registry() {
+                return new MyMetricRegistry("ROOT");
+            }
+
+            @Override
+            public MetricRegistry registry(String dbName) {
+                return new MyMetricRegistry(dbName);
+            }
+
+            @Override
+            public MetricRegistry registry(String dbName, String collectionName) {
+                return new MyMetricRegistry(dbName + "/" + collectionName);
+            }
+        };
+
+    }
+
+    MetricsHandler handler;
+
+    private Configuration configWith(Configuration.METRICS_GATHERING_LEVEL mgl) {
+        return new Configuration() {
+            @Override
+            public METRICS_GATHERING_LEVEL getMetricsGatheringLevel() {
+                return mgl;
+            }
+        };
+    }
+
+    @Test
+    public void testGetCorrectMetricRegistry() throws Exception {
+        HttpServerExchange httpServerExchange = mock(HttpServerExchange.class);
+        when(httpServerExchange.getStatusCode()).thenReturn(200);
+        when(httpServerExchange.getRequestMethod()).thenReturn(Methods.GET);
+        when(httpServerExchange.getRequestPath()).thenReturn("/");
+
+        RequestContext requestContext = new RequestContext(httpServerExchange, "/", "/foo/bar");
+
+        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.ROOT);
+        MetricRegistry registry = handler.getCorrectMetricRegistry(requestContext);
+        assertNull(registry);
+
+        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.DATABASE);
+        registry = handler.getCorrectMetricRegistry(requestContext);
+        assertNull(registry);
+
+        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.COLLECTION);
+        registry = handler.getCorrectMetricRegistry(requestContext);
+        assertTrue(registry instanceof MyMetricRegistry);
+        assertEquals("foo/bar", ((MyMetricRegistry) registry).getName());
+
+        when(httpServerExchange.getRequestPath()).thenReturn("/");
+        requestContext = new RequestContext(httpServerExchange, "/", "/foo");
+
+        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.ROOT);
+        registry = handler.getCorrectMetricRegistry(requestContext);
+        assertNull(registry);
+
+        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.DATABASE);
+        registry = handler.getCorrectMetricRegistry(requestContext);
+        assertTrue(registry instanceof MyMetricRegistry);
+        assertEquals("foo", ((MyMetricRegistry) registry).getName());
+
+        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.COLLECTION);
+        registry = handler.getCorrectMetricRegistry(requestContext);
+        assertTrue(registry instanceof MyMetricRegistry);
+        assertEquals("foo", ((MyMetricRegistry) registry).getName());
+
+        when(httpServerExchange.getRequestPath()).thenReturn("/");
+        requestContext = new RequestContext(httpServerExchange, "/", "/");
+
+        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.ROOT);
+        registry = handler.getCorrectMetricRegistry(requestContext);
+        assertTrue(registry instanceof MyMetricRegistry);
+        assertEquals("ROOT", ((MyMetricRegistry) registry).getName());
+
+        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.DATABASE);
+        registry = handler.getCorrectMetricRegistry(requestContext);
+        assertTrue(registry instanceof MyMetricRegistry);
+        assertEquals("ROOT", ((MyMetricRegistry) registry).getName());
+
+        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.COLLECTION);
+        registry = handler.getCorrectMetricRegistry(requestContext);
+        assertTrue(registry instanceof MyMetricRegistry);
+        assertEquals("ROOT", ((MyMetricRegistry) registry).getName());
+    }
+}

--- a/src/test/java/org/restheart/handlers/applicationlogic/ResponseTypeTest.java
+++ b/src/test/java/org/restheart/handlers/applicationlogic/ResponseTypeTest.java
@@ -1,0 +1,61 @@
+package org.restheart.handlers.applicationlogic;
+
+import org.junit.Test;
+import org.restheart.handlers.applicationlogic.MetricsHandler.ResponseType;
+import org.restheart.handlers.applicationlogic.MetricsHandler.ResponseType.AcceptHeaderEntry;
+
+import static org.junit.Assert.*;
+
+/**
+ * TODO: fillme
+ */
+public class ResponseTypeTest {
+
+    @Test
+    public void testIsAcceptableFor() throws Exception {
+        assertTrue(ResponseType.JSON.isAcceptableFor(AcceptHeaderEntry.of("application/json")));
+        assertTrue(ResponseType.JSON.isAcceptableFor(AcceptHeaderEntry.of("application/*")));
+        assertFalse(ResponseType.JSON.isAcceptableFor(AcceptHeaderEntry.of("text/*")));
+        assertTrue(ResponseType.JSON.isAcceptableFor(AcceptHeaderEntry.of("*/*")));
+        assertTrue(ResponseType.JSON.isAcceptableFor(AcceptHeaderEntry.of("application/json; q=0.9")));
+        assertFalse(ResponseType.JSON.isAcceptableFor(AcceptHeaderEntry.of("application/json; q=0.9; extraparameter=foobar")));
+        assertFalse(ResponseType.JSON.isAcceptableFor(AcceptHeaderEntry.of("text/plain")));
+        assertFalse(ResponseType.JSON.isAcceptableFor(AcceptHeaderEntry.of("text/plain; version=0.0.4")));
+        assertFalse(ResponseType.JSON.isAcceptableFor(AcceptHeaderEntry.of("text/plain; version=0.0.4; q=1.0")));
+        assertFalse(ResponseType.JSON.isAcceptableFor(AcceptHeaderEntry.of("text/plain; version= 0.0.3")));
+        assertFalse(ResponseType.JSON.isAcceptableFor(AcceptHeaderEntry.of("text/plain; version= 0.0.5")));
+
+
+        assertFalse(ResponseType.PROMETHEUS.isAcceptableFor(AcceptHeaderEntry.of("application/json")));
+        assertFalse(ResponseType.PROMETHEUS.isAcceptableFor(AcceptHeaderEntry.of("application/*")));
+        assertTrue(ResponseType.PROMETHEUS.isAcceptableFor(AcceptHeaderEntry.of("text/*")));
+        assertTrue(ResponseType.PROMETHEUS.isAcceptableFor(AcceptHeaderEntry.of("*/*")));
+        assertFalse(ResponseType.PROMETHEUS.isAcceptableFor(AcceptHeaderEntry.of("application/json; q=0.9")));
+        assertFalse(ResponseType.PROMETHEUS.isAcceptableFor(AcceptHeaderEntry.of("application/json; q=0.9; extraparameter=foobar")));
+        assertTrue(ResponseType.PROMETHEUS.isAcceptableFor(AcceptHeaderEntry.of("text/plain")));
+        assertTrue(ResponseType.PROMETHEUS.isAcceptableFor(AcceptHeaderEntry.of("text/plain; version=0.0.4")));
+        assertTrue(ResponseType.PROMETHEUS.isAcceptableFor(AcceptHeaderEntry.of("text/plain; version=0.0.4; q=1.0")));
+        assertFalse(ResponseType.PROMETHEUS.isAcceptableFor(AcceptHeaderEntry.of("text/plain; version= 0.0.3")));
+        assertFalse(ResponseType.PROMETHEUS.isAcceptableFor(AcceptHeaderEntry.of("text/plain; version= 0.0.5")));
+    }
+
+    @Test
+    public void testCalculateMediaRange() throws Exception {
+        assertEquals("application/*", ResponseType.calculateMediaRange("application/json"));
+        assertEquals("text/*", ResponseType.calculateMediaRange("text/plain"));
+    }
+
+    @Test
+    public void testResponseTypeCreation() throws Exception {
+        assertEquals(ResponseType.JSON, ResponseType.forAcceptHeader("application/json"));
+        assertEquals(ResponseType.PROMETHEUS, ResponseType.forAcceptHeader("text/plain"));
+        assertEquals(ResponseType.PROMETHEUS, ResponseType.forAcceptHeader("text/plain,application/json"));
+        assertEquals(ResponseType.PROMETHEUS, ResponseType.forAcceptHeader("text/plain, application/json"));
+        assertEquals(ResponseType.JSON, ResponseType.forAcceptHeader("text/plain; q=0.1, application/json"));
+        assertEquals(ResponseType.JSON, ResponseType.forAcceptHeader("text/plain; q=0.1, application/json; q=1.0"));
+
+        assertEquals(ResponseType.JSON, ResponseType.forQueryParameter("PLAIN_JSON"));
+        assertEquals(ResponseType.JSON, ResponseType.forQueryParameter("PJ"));
+        assertEquals(null, ResponseType.forQueryParameter("foobar"));
+    }
+}

--- a/src/test/java/org/restheart/test/integration/GetMetricsIT.java
+++ b/src/test/java/org/restheart/test/integration/GetMetricsIT.java
@@ -1,0 +1,105 @@
+/*
+ * RESTHeart - the Web API for MongoDB
+ * Copyright (C) SoftInstigate Srl
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.restheart.test.integration;
+
+import com.eclipsesource.json.JsonArray;
+import com.eclipsesource.json.JsonObject;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.client.fluent.Request;
+import org.apache.http.client.fluent.Response;
+import org.apache.http.util.EntityUtils;
+import org.junit.Test;
+import org.restheart.hal.Representation;
+import org.restheart.utils.HttpStatus;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ *
+ * @author Andrea Di Cesare {@literal <andrea@softinstigate.com>}
+ */
+public class GetMetricsIT extends HttpClientAbstactIT {
+
+    public GetMetricsIT() {
+    }
+
+    @Test
+    public void testGetMetrics() throws Exception {
+        Response resp = adminExecutor.execute(Request.Get(metricsUri).addHeader("Accept", "application/json"));
+
+        HttpResponse httpResp = resp.returnResponse();
+        assertNotNull(httpResp);
+        HttpEntity entity = httpResp.getEntity();
+        assertNotNull(entity);
+        StatusLine statusLine = httpResp.getStatusLine();
+        assertNotNull(statusLine);
+
+        assertEquals("check status code", HttpStatus.SC_OK, statusLine.getStatusCode());
+        assertNotNull("content type not null", entity.getContentType());
+        assertEquals("check content type", Representation.JSON_MEDIA_TYPE, entity.getContentType().getValue());
+
+        String content = EntityUtils.toString(entity);
+        assertTrue(content.contains("\"version\" : \"3.0.0\""));
+        assertTrue(content.contains("\"DB.GET\" : {"));
+    }
+
+    @Test
+    public void testGetMetricsPrometheus() throws Exception {
+        Response resp = adminExecutor.execute(Request.Get(metricsUri));
+
+        HttpResponse httpResp = resp.returnResponse();
+        assertNotNull(httpResp);
+        HttpEntity entity = httpResp.getEntity();
+        assertNotNull(entity);
+        StatusLine statusLine = httpResp.getStatusLine();
+        assertNotNull(statusLine);
+
+        assertEquals("check status code", HttpStatus.SC_OK, statusLine.getStatusCode());
+        assertNotNull("content type not null", entity.getContentType());
+        assertEquals("check content type", "text/plain; version=0.0.4", entity.getContentType().getValue());
+    }
+
+    @Test
+    public void testGetMetricsForUnknownCollection() throws Exception {
+        Response resp = adminExecutor.execute(Request.Get(metricsUnknownCollectionUri));
+
+        HttpResponse httpResp = resp.returnResponse();
+        assertNotNull(httpResp);
+        HttpEntity entity = httpResp.getEntity();
+        assertNotNull(entity);
+        StatusLine statusLine = httpResp.getStatusLine();
+        assertNotNull(statusLine);
+
+        //configuration says: it is not activated for collections, so it should return 404, default restheart answer
+        assertEquals("check status code", HttpStatus.SC_NOT_FOUND, statusLine.getStatusCode());
+        assertNotNull("content type not null", entity.getContentType());
+        assertEquals("check content type", "application/hal+json", entity.getContentType().getValue());
+    }
+}

--- a/src/test/java/org/restheart/test/integration/HttpClientAbstactIT.java
+++ b/src/test/java/org/restheart/test/integration/HttpClientAbstactIT.java
@@ -106,6 +106,8 @@ public abstract class HttpClientAbstactIT extends AbstactIT {
     protected static URI documentTmpUri;
     protected static URI indexesTmpUri;
     protected static URI indexTmpUri;
+    protected static URI metricsUri;
+    protected static URI metricsUnknownCollectionUri;
     protected static final String document1Id = "doc1";
     protected static final String document2Id = "doc2";
     protected static final String documentTmpId = "tmpdoc";
@@ -358,6 +360,8 @@ public abstract class HttpClientAbstactIT extends AbstactIT {
         document2UriRemappedDocument = buildURI(REMAPPEDDOC2, new NameValuePair[]{
             new BasicNameValuePair("hal", "f")
         });
+        metricsUri = buildURI("/_metrics");
+        metricsUnknownCollectionUri = buildURI("/someunknowndb/unknowncollection/_metrics");
     }
 
     protected static URI buildURI(String path, NameValuePair[] parameters) throws URISyntaxException {

--- a/src/test/java/org/restheart/utils/MetricsJsonGeneratorTest.java
+++ b/src/test/java/org/restheart/utils/MetricsJsonGeneratorTest.java
@@ -1,0 +1,81 @@
+package org.restheart.utils;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+
+import org.bson.BsonDocument;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+public class MetricsJsonGeneratorTest {
+
+    JsonWriterSettings writerSettings = JsonWriterSettings.builder().outputMode(JsonMode.RELAXED).indent(false).build();
+
+    @Test
+    public void testGenerationWithEmptyRegistry() throws Exception {
+        MetricRegistry registry = new MetricRegistry();
+        BsonDocument bson = MetricsJsonGenerator.generateMetricsBson(registry, TimeUnit.SECONDS, TimeUnit.MILLISECONDS);
+        assertEquals(
+            "{ \"version\" : \"3.0.0\", \"gauges\" : { }, \"counters\" : { }, \"histograms\" : { }, \"meters\" : { }, \"timers\" : { } }",
+            bson.toJson()
+        );
+    }
+
+    @Test
+    public void testGenerationWithOneTimer() throws Exception {
+        MetricRegistry registry = new MetricRegistry();
+        registry.timer("foobar").update(5, TimeUnit.MILLISECONDS);
+        BsonDocument bson = MetricsJsonGenerator.generateMetricsBson(registry, TimeUnit.SECONDS, TimeUnit.MILLISECONDS);
+        assertEquals("{ \"version\" : \"3.0.0\", \"gauges\" : { }, \"counters\" : { }, \"histograms\" : { }, \"meters\" : { }, \"timers\" : { \"foobar\" : { \"count\" : 1, \"max\" : 5.0, \"mean\" : 5.0, \"min\" : 5.0, \"p50\" : 5.0, \"p75\" : 5.0, \"p95\" : 5.0, \"p98\" : 5.0, \"p99\" : 5.0, \"p999\" : 5.0, \"stddev\" : 0.0, \"m15_rate\" : 0.0, \"m1_rate\" : 0.0, \"m5_rate\" : 0.0, \"mean_rate\" : 1, \"duration_units\" : \"milliseconds\", \"rate_units\" : \"calls/second\" } } }",
+                     bson.toJson(writerSettings)
+                     //mean_rate is different for each call, so set it fixed for the test output
+                     .replaceAll("\"mean_rate\" : [0-9.]+", "\"mean_rate\" : 1"));
+    }
+
+    @Test
+    public void testGenerationWithGauges() throws Exception {
+        MetricRegistry registry = new MetricRegistry();
+        registry.gauge("foobar", () -> () -> 5);
+        BsonDocument bson = MetricsJsonGenerator.generateMetricsBson(registry, TimeUnit.SECONDS, TimeUnit.MILLISECONDS);
+        assertEquals("{ \"version\" : \"3.0.0\", \"gauges\" : { \"foobar\" : { \"value\" : 5 } }, \"counters\" : { }, \"histograms\" : { }, \"meters\" : { }, \"timers\" : { } }",
+                     bson.toJson(writerSettings));
+    }
+
+    @Test
+    public void testGenerationWithHistogram() throws Exception {
+        MetricRegistry registry = new MetricRegistry();
+        registry.histogram("foobar").update(5);
+        BsonDocument bson = MetricsJsonGenerator.generateMetricsBson(registry, TimeUnit.SECONDS, TimeUnit.MILLISECONDS);
+        assertEquals("{ \"version\" : \"3.0.0\", \"gauges\" : { }, \"counters\" : { }, \"histograms\" : { \"foobar\" : { \"count\" : 1, \"max\" : 5.0, \"mean\" : 5.0, \"min\" : 5.0, \"p50\" : 5.0, \"p75\" : 5.0, \"p95\" : 5.0, \"p98\" : 5.0, \"p99\" : 5.0, \"p999\" : 5.0, \"stddev\" : 0.0 } }, \"meters\" : { }, \"timers\" : { } }",
+                     bson.toJson(writerSettings));
+    }
+
+    @Test
+    public void testGenerationWithCounter() throws Exception {
+        MetricRegistry registry = new MetricRegistry();
+        Counter counter = registry.counter("foobar");
+        counter.inc();
+        counter.inc();
+        counter.inc();
+        BsonDocument bson = MetricsJsonGenerator.generateMetricsBson(registry, TimeUnit.SECONDS, TimeUnit.MILLISECONDS);
+        assertEquals("{ \"version\" : \"3.0.0\", \"gauges\" : { }, \"counters\" : { \"foobar\" : { \"count\" : 3 } }, \"histograms\" : { }, \"meters\" : { }, \"timers\" : { } }",
+                     bson.toJson(writerSettings));
+    }
+
+    @Test
+    public void testGenerationWithMeter() throws Exception {
+        MetricRegistry registry = new MetricRegistry();
+        registry.meter("foobar").mark();
+        BsonDocument bson = MetricsJsonGenerator.generateMetricsBson(registry, TimeUnit.SECONDS, TimeUnit.MILLISECONDS);
+        assertEquals("{ \"version\" : \"3.0.0\", \"gauges\" : { }, \"counters\" : { }, \"histograms\" : { }, \"meters\" : { \"foobar\" : { \"count\" : 1, \"m15_rate\" : 0.0, \"m1_rate\" : 0.0, \"m5_rate\" : 0.0, \"mean_rate\" : 1, \"units\" : \"calls/second\" } }, \"timers\" : { } }",
+             bson.toJson(writerSettings)
+                 //mean_rate is different for each call, so set it fixed for the test output
+                 .replaceAll("\"mean_rate\" : [0-9.]+", "\"mean_rate\" : 1")
+        );
+    }
+}


### PR DESCRIPTION
This pull-request will close #249 .

It adds support for metrics to restheart and behaves as follows:

There are a few new endpoints:
* `/_metrics`
* `/$DBNAME/_metrics`
* `/$DBNAME/$COLLECTIONNAME/_metrics`.

You can query them to get metrics information; each upper level contains all the information from the lower levels, aggregated. There are two output formats: classic dropwizard metrics JSON format (see https://github.com/iZettle/dropwizard-metrics/blob/master/metrics-json/src/main/java/io/dropwizard/metrics/json/MetricsModule.java for the format) and Prometheus (see https://prometheus.io/docs/instrumenting/exposition_formats/).

Prometheus is the default format and will be selected if you do not specify anything. This allows easier integration into a k8s stack (e.g. for auto-scaling by response time).
For the JSON format, there are 2 options: Use the `rep` query parameter set to `PJ` or `PLAIN_JSON` (as you know it from classic restheart), or use HTTP content negotiation using `Accept` headers (see https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1). If you give both, the query parameter wins.

Whether restheart will collect metrics at all depends on the `metrics-gathering-level` defined in the config file (default is `ROOT`). You can set it to `OFF`, `ROOT`, `DATABASE` or `COLLECTION`, which will in turn collect from least to most metrics. If metrics do not get gathered at a given level, the answer from the respective endpoint will be `404 NOT FOUND`.

If I should make changes to the current implementation, tell me, I am open for suggestions :).