### PR TITLE
fixed a bug: JSON format was preferred over PROMETHEUS in some cases for _metrics

### DIFF
--- a/src/main/java/org/restheart/handlers/applicationlogic/MetricsHandler.java
+++ b/src/main/java/org/restheart/handlers/applicationlogic/MetricsHandler.java
@@ -254,7 +254,7 @@ public class MetricsHandler extends PipedHttpHandler {
          * * if Accept header cannot be satisfied, return 406 (NOT ACCEPTABLE)
          */
         public static ResponseType forAcceptHeader(String acceptHeader) {
-            if (acceptHeader == null) {
+            if (acceptHeader == null || acceptHeader.equalsIgnoreCase("*/*")) {
                 return ResponseType.PROMETHEUS;
             }
             return Arrays.stream(acceptHeader.split(","))


### PR DESCRIPTION
When accept header had "*/*", then JSON format was preferred over PROMETHEUS, in contrast to what has been done in case the header was not present at all. I found this when playing with it to write the docs.

PROMETHEUS format is preferred over JSON by the implementation normally. This has more or less technical reasons: the `rep` parameter is handled globally in restheart, and supporting that query parameter for explicitly selecting the prometheus format could not have been done without major refactorings. Therefore, prometheus is the default format, and JSON can easily be selected.

That was already the case when the parameter has been omitted in the request. When you supplied `*/*`, the behaviour was different, which should not be the case (see https://tools.ietf.org/html/rfc2616#page-101)