### PR TITLE
RESTHEART prepared to be embedded in an Undertow application.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>io.undertow</groupId>
             <artifactId>undertow-core</artifactId>
-            <version>1.4.22.Final</version>
+            <version>1.4.23.Final</version>
         </dependency>
         
         <dependency>

--- a/src/main/java/org/restheart/db/MongoDBClientSingleton.java
+++ b/src/main/java/org/restheart/db/MongoDBClientSingleton.java
@@ -34,6 +34,7 @@ public class MongoDBClientSingleton {
     private static boolean initialized = false;
 
     private static MongoClientURI mongoUri;
+    private static MongoClient outsideMongoClient;
 
     private static String serverVersion;
 
@@ -46,6 +47,12 @@ public class MongoDBClientSingleton {
     public static void init(Configuration conf) {
         mongoUri = conf.getMongoUri();
         initialized = true;
+    }
+
+    public static void init(MongoClient outsideMongoClient) {
+        initialized = true;
+        MongoDBClientSingleton.outsideMongoClient = outsideMongoClient;
+        serverVersion = "?";
     }
 
     /**
@@ -77,7 +84,7 @@ public class MongoDBClientSingleton {
         }
 
         try {
-            setup();
+            setup(outsideMongoClient);
         } catch (UnknownHostException ex) {
             LOGGER.error("error initializing mongodb client", ex);
         } catch (Throwable tr) {
@@ -85,9 +92,10 @@ public class MongoDBClientSingleton {
         }
     }
 
-    private void setup() throws UnknownHostException {
+    private void setup(MongoClient outsideMongoClient) throws UnknownHostException {
         if (isInitialized()) {
-            mongoClient = new MongoClient(mongoUri);
+
+            mongoClient = outsideMongoClient != null ? outsideMongoClient : new MongoClient(mongoUri);
         }
 
         try {


### PR DESCRIPTION
Minimal code change to embed RESTHEART into an undertow application. The main application provides to RESTHEART the configuration of RESTHEART , the MongoClient and the Undertow server.

For example embedding in spring-boot application:

 ```
       @Bean
        public UndertowServletWebServerFactory undertowReactiveWebServerFactory(RootHandlerForRestHeartDispatching rootHandlerForRestHeartDispatching) {

            UndertowServletWebServerFactory undertowServletWebServerFactory = new UndertowServletWebServerFactory();
            undertowServletWebServerFactory.addDeploymentInfoCustomizers(deploymentInfo ->
                    deploymentInfo.addInitialHandlerChainWrapper(rootHandlerForRestHeartDispatching::setNext));

            return undertowServletWebServerFactory;
        }

        @Bean
        public HttpHandler restHeartHandler(RestHeartConfigurationProperties configurationProperties, MongoClient mongoClient) {
            Configuration restHeartConfiguration = configurationProperties.buildConfiguration();
            MongoDBClientSingleton.init(mongoClient);
            return Bootstrapper.buildCoreSystem(restHeartConfiguration);
        }
```