### PR TITLE
#304 - handle MongoGridFSException when deleting a GriFS file

### DIFF
--- a/src/main/java/org/restheart/db/GridFsDAO.java
+++ b/src/main/java/org/restheart/db/GridFsDAO.java
@@ -19,6 +19,7 @@ package org.restheart.db;
  */
 import com.mongodb.DuplicateKeyException;
 import com.mongodb.MongoClient;
+import com.mongodb.MongoGridFSException;
 import com.mongodb.client.gridfs.GridFSBucket;
 import com.mongodb.client.gridfs.GridFSBuckets;
 import com.mongodb.client.gridfs.model.GridFSFile;
@@ -160,7 +161,13 @@ public class GridFsDAO implements GridFsRepository {
             }
         }
 
-        gridFSBucket.delete(fileId);
+        // Even checking the existence of file before,
+        // It's possible that the is already deleted at this point (due to concurrency problems).
+        try {
+            gridFSBucket.delete(fileId);
+        } catch (MongoGridFSException e) {
+            return new OperationResult(HttpStatus.SC_NOT_FOUND);
+        }
 
         return new OperationResult(HttpStatus.SC_NO_CONTENT);
     }


### PR DESCRIPTION
As pointed in the issue #304 an `MongoGridFSException` could occur if the file doesn't exist when trying to delete.

Mongo's `GridFSBucket` is thread-safe, but `deleteFile` method in `GridFsDAO` is not, so concurrency problems can occur.

I'm not sure if just handle the exception and return HTTP/404 is the best option, what do you guys think?



