### PR TITLE
Refactor Prometheus metrics to a single timeseries allowing easier aggregation

### DIFF
--- a/src/main/java/org/restheart/handlers/applicationlogic/MetricsHandler.java
+++ b/src/main/java/org/restheart/handlers/applicationlogic/MetricsHandler.java
@@ -215,10 +215,9 @@ public class MetricsHandler extends PipedHttpHandler {
 
                             metricContent.asDocument().forEach((metricType, value) -> {
                                 if (value.isNumber()) {
-                                    sb.append("http_response_").append(groupKey)
-                                        .append("_").append(type).append("_")
-                                        .append(metricType);
+                                    sb.append("http_response_").append(groupKey).append("_").append(metricType);
                                     sb.append("{");
+                                    sb.append("type=\"").append(type).append("\",");
                                     sb.append("method=\"").append(method).append("\"");
                                     if (responseCode != null) {
                                         sb.append(",");


### PR DESCRIPTION
Hi,

I've refactored the prometheus metrics generation to produce a single timeseries only. This allows easiert aggregation in Grafana or similar, because now you can use the aggregation functions from prometheus query language itself and you don't have to rely on functionality in Grafana or other tools.

We had the problem aggregating (sum) the count of requests per response type, because grafana does not create the sum if not all timeserien are present. So if no request for files/assets was made, no metrics are displayed resulting in useless dashboards.