### PR TITLE
provide prometheus metrics per database and collection using labels

### DIFF
--- a/src/main/java/org/restheart/utils/SharedMetricRegistryProxy.java
+++ b/src/main/java/org/restheart/utils/SharedMetricRegistryProxy.java
@@ -3,18 +3,40 @@ package org.restheart.utils;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.SharedMetricRegistries;
 
+import java.util.stream.Stream;
+
 /**
  * A proxy to the shared metrics registry, mainly to make unit testing easier (extend and inject to object-under-test)
  */
 public class SharedMetricRegistryProxy {
-    private static final MetricRegistry defaultRegistry = SharedMetricRegistries.getOrCreate("default");
-    public MetricRegistry registry() {
-        return defaultRegistry;
+
+    private static final String DEFAULT_NAME = "default";
+
+    public SharedMetricRegistryProxy() {
+
+        // initialize default metrics registry name, if not already set
+        if(SharedMetricRegistries.tryGetDefault() == null) {
+            SharedMetricRegistries.setDefault(DEFAULT_NAME);
+        }
     }
+
+    public boolean isDefault(String databaseName) {
+        return DEFAULT_NAME.equals(databaseName);
+    }
+
+    public MetricRegistry registry() {
+        return SharedMetricRegistries.tryGetDefault();
+    }
+
     public MetricRegistry registry(String dbName) {
         return SharedMetricRegistries.getOrCreate(dbName);
     }
+
     public MetricRegistry registry(String dbName, String collectionName) {
         return SharedMetricRegistries.getOrCreate(dbName + "/" + collectionName);
+    }
+
+    public Stream<String> registries() {
+        return SharedMetricRegistries.names().stream();
     }
 }

--- a/src/test/java/org/restheart/handlers/applicationlogic/MetricsHandlerResponseTypePrometheusTest.java
+++ b/src/test/java/org/restheart/handlers/applicationlogic/MetricsHandlerResponseTypePrometheusTest.java
@@ -1,0 +1,172 @@
+package org.restheart.handlers.applicationlogic;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.SharedMetricRegistries;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.restheart.Configuration.METRICS_GATHERING_LEVEL.COLLECTION;
+import static org.restheart.Configuration.METRICS_GATHERING_LEVEL.DATABASE;
+import static org.restheart.Configuration.METRICS_GATHERING_LEVEL.ROOT;
+
+public class MetricsHandlerResponseTypePrometheusTest {
+
+    private static final String REGISTRY_NAME_DATABASE = "fancy-shop";
+    private static final String REGISTRY_NAME_COLLECTION = "products";
+
+    private static final String METRICS_TIMER_NAME = "requests.GET.2xx";
+
+    private static final Pattern TIMESTAMP_PATTERN = Pattern.compile("http_response_timers_.+\\{.+\\} \\d+\\.*\\d* (\\d+)");
+    private static final Pattern MEAN_RATE_PATTERN = Pattern.compile("http_response_timers_mean_rate\\{.+\\} (\\d+\\.\\d+) \\$TIMESTAMP\\$");
+
+    MetricsHandler handler;
+
+    MetricRegistry rootRegistry;
+    MetricRegistry databaseRegistry;
+    MetricRegistry collectionRegistry;
+
+    @Before
+    public void setUp() {
+
+        // we need to clear the metrics before each run, because they are kept static and thus would alter with each test, but we want static sample data!
+        SharedMetricRegistries.clear();
+
+        // create a new handler
+        handler = new MetricsHandler(null, null);
+
+        // provide sample metrics data (MetricsInstrumentationHandler uses timers only, so we create sample data for timers only)
+        collectionRegistry = handler.metrics.registry(REGISTRY_NAME_DATABASE, REGISTRY_NAME_COLLECTION);
+        updateTimer(collectionRegistry, 10);
+
+        databaseRegistry = handler.metrics.registry(REGISTRY_NAME_DATABASE);
+        updateTimer(databaseRegistry, 10);
+        updateTimer(databaseRegistry, 5);
+
+        rootRegistry = handler.metrics.registry();
+        updateTimer(rootRegistry, 10);
+        updateTimer(rootRegistry, 5);
+        updateTimer(rootRegistry, 2);
+    }
+
+    private void updateTimer(MetricRegistry registry, long timerValue) {
+        registry.timer(METRICS_TIMER_NAME).update(timerValue, TimeUnit.MILLISECONDS);
+    }
+
+    @Test
+    public void testMetricsForRoot() throws IOException {
+        String expectedMetrics = "http_response_timers_count{database=\"_all_\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 3 $TIMESTAMP$\n" +
+                "http_response_timers_max{database=\"_all_\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_mean{database=\"_all_\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 5.666666666666666 $TIMESTAMP$\n" +
+                "http_response_timers_min{database=\"_all_\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 2.0 $TIMESTAMP$\n" +
+                "http_response_timers_p50{database=\"_all_\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 5.0 $TIMESTAMP$\n" +
+                "http_response_timers_p75{database=\"_all_\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p95{database=\"_all_\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p98{database=\"_all_\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p99{database=\"_all_\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p999{database=\"_all_\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_stddev{database=\"_all_\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 3.299831645537221 $TIMESTAMP$\n" +
+                "http_response_timers_m15_rate{database=\"_all_\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_m1_rate{database=\"_all_\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_m5_rate{database=\"_all_\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_mean_rate{database=\"_all_\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} $MEAN_RATE$ $TIMESTAMP$\n" +
+                "\n" +
+                "http_response_timers_count{database=\"fancy-shop\",collection=\"products\",type=\"requests\",method=\"GET\",code=\"2xx\"} 1 $TIMESTAMP$\n" +
+                "http_response_timers_max{database=\"fancy-shop\",collection=\"products\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_mean{database=\"fancy-shop\",collection=\"products\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_min{database=\"fancy-shop\",collection=\"products\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p50{database=\"fancy-shop\",collection=\"products\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p75{database=\"fancy-shop\",collection=\"products\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p95{database=\"fancy-shop\",collection=\"products\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p98{database=\"fancy-shop\",collection=\"products\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p99{database=\"fancy-shop\",collection=\"products\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p999{database=\"fancy-shop\",collection=\"products\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_stddev{database=\"fancy-shop\",collection=\"products\",type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_m15_rate{database=\"fancy-shop\",collection=\"products\",type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_m1_rate{database=\"fancy-shop\",collection=\"products\",type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_m5_rate{database=\"fancy-shop\",collection=\"products\",type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_mean_rate{database=\"fancy-shop\",collection=\"products\",type=\"requests\",method=\"GET\",code=\"2xx\"} $MEAN_RATE$ $TIMESTAMP$\n" +
+                "\n" +
+                "http_response_timers_count{database=\"fancy-shop\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 2 $TIMESTAMP$\n" +
+                "http_response_timers_max{database=\"fancy-shop\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_mean{database=\"fancy-shop\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 7.5 $TIMESTAMP$\n" +
+                "http_response_timers_min{database=\"fancy-shop\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 5.0 $TIMESTAMP$\n" +
+                "http_response_timers_p50{database=\"fancy-shop\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p75{database=\"fancy-shop\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p95{database=\"fancy-shop\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p98{database=\"fancy-shop\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p99{database=\"fancy-shop\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p999{database=\"fancy-shop\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_stddev{database=\"fancy-shop\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 2.5 $TIMESTAMP$\n" +
+                "http_response_timers_m15_rate{database=\"fancy-shop\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_m1_rate{database=\"fancy-shop\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_m5_rate{database=\"fancy-shop\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_mean_rate{database=\"fancy-shop\",collection=\"_all_\",type=\"requests\",method=\"GET\",code=\"2xx\"} $MEAN_RATE$ $TIMESTAMP$";
+        assertMetrics(expectedMetrics, MetricsHandler.ResponseType.PROMETHEUS.generateResponse(ROOT, rootRegistry));
+    }
+
+    @Test
+    public void testMetricsForDatabase() throws IOException {
+        String expectedMetrics = "http_response_timers_count{type=\"requests\",method=\"GET\",code=\"2xx\"} 2 $TIMESTAMP$\n" +
+                "http_response_timers_max{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_mean{type=\"requests\",method=\"GET\",code=\"2xx\"} 7.5 $TIMESTAMP$\n" +
+                "http_response_timers_min{type=\"requests\",method=\"GET\",code=\"2xx\"} 5.0 $TIMESTAMP$\n" +
+                "http_response_timers_p50{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p75{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p95{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p98{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p99{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p999{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_stddev{type=\"requests\",method=\"GET\",code=\"2xx\"} 2.5 $TIMESTAMP$\n" +
+                "http_response_timers_m15_rate{type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_m1_rate{type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_m5_rate{type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_mean_rate{type=\"requests\",method=\"GET\",code=\"2xx\"} $MEAN_RATE$ $TIMESTAMP$";
+        assertMetrics(expectedMetrics, MetricsHandler.ResponseType.PROMETHEUS.generateResponse(DATABASE, databaseRegistry));
+    }
+
+    @Test
+    public void testMetricsForCollection() throws IOException {
+        String expectedMetrics = "http_response_timers_count{type=\"requests\",method=\"GET\",code=\"2xx\"} 1 $TIMESTAMP$\n" +
+                "http_response_timers_max{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_mean{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_min{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p50{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p75{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p95{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p98{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p99{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_p999{type=\"requests\",method=\"GET\",code=\"2xx\"} 10.0 $TIMESTAMP$\n" +
+                "http_response_timers_stddev{type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_m15_rate{type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_m1_rate{type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_m5_rate{type=\"requests\",method=\"GET\",code=\"2xx\"} 0.0 $TIMESTAMP$\n" +
+                "http_response_timers_mean_rate{type=\"requests\",method=\"GET\",code=\"2xx\"} $MEAN_RATE$ $TIMESTAMP$";
+        assertMetrics(expectedMetrics, MetricsHandler.ResponseType.PROMETHEUS.generateResponse(COLLECTION, collectionRegistry));
+    }
+
+    private void assertMetrics(String expectedMetrics, String metrics) {
+        assertEquals(expectedMetrics, replaceDynamicValues(metrics));
+    }
+
+    private String replaceDynamicValues(String metrics) {
+        metrics = replaceMetricsValues(metrics, TIMESTAMP_PATTERN, "$TIMESTAMP$");
+        metrics = replaceMetricsValues(metrics, MEAN_RATE_PATTERN, "$MEAN_RATE$");
+        return metrics;
+    }
+
+    private String replaceMetricsValues(String metrics, Pattern pattern, String replacement) {
+        Matcher matcher = pattern.matcher(metrics);
+        while(matcher.find()) {
+            String toBeReplaced = matcher.group(1);
+            metrics = metrics.replaceAll(toBeReplaced, Matcher.quoteReplacement(replacement));
+        }
+
+        return metrics;
+    }
+}

--- a/src/test/java/org/restheart/handlers/applicationlogic/MetricsHandlerTest.java
+++ b/src/test/java/org/restheart/handlers/applicationlogic/MetricsHandlerTest.java
@@ -1,46 +1,96 @@
 package org.restheart.handlers.applicationlogic;
 
-import com.codahale.metrics.MetricRegistry;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Methods;
 import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.restheart.Configuration.METRICS_GATHERING_LEVEL.COLLECTION;
+import static org.restheart.Configuration.METRICS_GATHERING_LEVEL.DATABASE;
+import static org.restheart.Configuration.METRICS_GATHERING_LEVEL.OFF;
+import static org.restheart.Configuration.METRICS_GATHERING_LEVEL.ROOT;
+
 import org.restheart.Configuration;
 import org.restheart.handlers.RequestContext;
 import org.restheart.utils.SharedMetricRegistryProxy;
 
 public class MetricsHandlerTest {
 
+    private static final String URI_METRICS_ROOT = "/_metrics";
+    private static final String URI_METRICS_DATABASE = "/foo/_metrics";
+    private static final String URI_METRICS_COLLECTION = "/foo/bar/_metrics";
 
     MetricsHandler handler;
+
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         handler = new MetricsHandler(null, null);
-        handler.configuration = new Configuration();
-        handler.metrics = new SharedMetricRegistryProxy(){
-            @Override
-            public MetricRegistry registry() {
-                return new MyMetricRegistry("ROOT");
-            }
+        handler.metrics = mock(SharedMetricRegistryProxy.class);
+    }
 
-            @Override
-            public MetricRegistry registry(String dbName) {
-                return new MyMetricRegistry(dbName);
-            }
+    @Test
+    public void testRequestContextForMetricsRequestToRoot() {
+        assertRequestContextForMetricsRequest(createRequestContext(URI_METRICS_ROOT), "_metrics", null);
+    }
 
-            @Override
-            public MetricRegistry registry(String dbName, String collectionName) {
-                return new MyMetricRegistry(dbName + "/" + collectionName);
-            }
-        };
+    @Test
+    public void testRequestContextForMetricsRequestToDatabase() {
+        assertRequestContextForMetricsRequest(createRequestContext(URI_METRICS_DATABASE), "foo", "_metrics");
+    }
 
+    @Test
+    public void testRequestContextForMetricsRequestToCollection() {
+        assertRequestContextForMetricsRequest(createRequestContext(URI_METRICS_COLLECTION), "foo", "bar");
+    }
+
+    private void assertRequestContextForMetricsRequest(RequestContext requestContext, String expectedDatabaseName, String expectedCollectionName) {
+        assertEquals(expectedDatabaseName, requestContext.getDBName());
+        assertEquals(expectedCollectionName, requestContext.getCollectionName());
+    }
+
+    @Test
+    public void testMetricsLevelForRequestToRoot() {
+        assertMetricsLevelForRequest(URI_METRICS_ROOT, OFF, ROOT, ROOT, ROOT);
+    }
+
+    @Test
+    public void testMetricsLevelForRequestToDatabase() {
+        assertMetricsLevelForRequest(URI_METRICS_DATABASE, OFF, OFF, DATABASE, DATABASE);
+    }
+
+    @Test
+    public void testMetricsLevelForRequestToCollection() {
+        assertMetricsLevelForRequest(URI_METRICS_COLLECTION, OFF, OFF, OFF, COLLECTION);
+    }
+
+    private void assertMetricsLevelForRequest(String requestUri, Configuration.METRICS_GATHERING_LEVEL expectedLevelForConfigOff,
+            Configuration.METRICS_GATHERING_LEVEL expectedLevelForConfigRoot, Configuration.METRICS_GATHERING_LEVEL expectedLevelForConfigDatabase,
+            Configuration.METRICS_GATHERING_LEVEL expectedLevelForConfigCollection) {
+
+        RequestContext requestContext = createRequestContext(requestUri);
+
+        handler.configuration = configWith(OFF);
+        assertEquals(expectedLevelForConfigOff, handler.getMetricsLevelForRequest(requestContext));
+
+        handler.configuration = configWith(ROOT);
+        assertEquals(expectedLevelForConfigRoot, handler.getMetricsLevelForRequest(requestContext));
+
+        handler.configuration = configWith(DATABASE);
+        assertEquals(expectedLevelForConfigDatabase, handler.getMetricsLevelForRequest(requestContext));
+
+        handler.configuration = configWith(COLLECTION);
+        assertEquals(expectedLevelForConfigCollection, handler.getMetricsLevelForRequest(requestContext));
     }
 
     private Configuration configWith(Configuration.METRICS_GATHERING_LEVEL mgl) {
         return new Configuration() {
+
             @Override
             public METRICS_GATHERING_LEVEL getMetricsGatheringLevel() {
                 return mgl;
@@ -49,70 +99,32 @@ public class MetricsHandlerTest {
     }
 
     @Test
-    public void testGetCorrectMetricRegistry() throws Exception {
-        HttpServerExchange httpServerExchange = mock(HttpServerExchange.class);
-        when(httpServerExchange.getStatusCode()).thenReturn(200);
-        when(httpServerExchange.getRequestMethod()).thenReturn(Methods.GET);
-        when(httpServerExchange.getRequestPath()).thenReturn("/");
-
-        RequestContext requestContext = new RequestContext(httpServerExchange, "/", "/foo/bar");
-
-        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.ROOT);
-        MetricRegistry registry = handler.getCorrectMetricRegistry(requestContext);
-        assertNull(registry);
-
-        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.DATABASE);
-        registry = handler.getCorrectMetricRegistry(requestContext);
-        assertNull(registry);
-
-        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.COLLECTION);
-        registry = handler.getCorrectMetricRegistry(requestContext);
-        assertTrue(registry instanceof MyMetricRegistry);
-        assertEquals("foo/bar", ((MyMetricRegistry) registry).getName());
-
-        when(httpServerExchange.getRequestPath()).thenReturn("/");
-        requestContext = new RequestContext(httpServerExchange, "/", "/foo");
-
-        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.ROOT);
-        registry = handler.getCorrectMetricRegistry(requestContext);
-        assertNull(registry);
-
-        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.DATABASE);
-        registry = handler.getCorrectMetricRegistry(requestContext);
-        assertTrue(registry instanceof MyMetricRegistry);
-        assertEquals("foo", ((MyMetricRegistry) registry).getName());
-
-        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.COLLECTION);
-        registry = handler.getCorrectMetricRegistry(requestContext);
-        assertTrue(registry instanceof MyMetricRegistry);
-        assertEquals("foo", ((MyMetricRegistry) registry).getName());
-
-        when(httpServerExchange.getRequestPath()).thenReturn("/");
-        requestContext = new RequestContext(httpServerExchange, "/", "/");
-
-        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.ROOT);
-        registry = handler.getCorrectMetricRegistry(requestContext);
-        assertTrue(registry instanceof MyMetricRegistry);
-        assertEquals("ROOT", ((MyMetricRegistry) registry).getName());
-
-        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.DATABASE);
-        registry = handler.getCorrectMetricRegistry(requestContext);
-        assertTrue(registry instanceof MyMetricRegistry);
-        assertEquals("ROOT", ((MyMetricRegistry) registry).getName());
-
-        handler.configuration = configWith(Configuration.METRICS_GATHERING_LEVEL.COLLECTION);
-        registry = handler.getCorrectMetricRegistry(requestContext);
-        assertTrue(registry instanceof MyMetricRegistry);
-        assertEquals("ROOT", ((MyMetricRegistry) registry).getName());
+    public void testMetricsRegistryForRequestToRoot() {
+        RequestContext requestContext = createRequestContext(URI_METRICS_ROOT);
+        handler.getMetricsRegistry(requestContext, ROOT);
+        verify(handler.metrics, times(1)).registry();
     }
-    class MyMetricRegistry extends MetricRegistry {
-        String name;
-        MyMetricRegistry(String name) {
-            this.name = name;
-        }
-        
-        public String getName() {
-            return name;
-        }
+
+    @Test
+    public void testMetricsRegistryForRequestToDatabase() {
+        RequestContext requestContext = createRequestContext(URI_METRICS_DATABASE);
+        handler.getMetricsRegistry(requestContext, DATABASE);
+        verify(handler.metrics, times(1)).registry(eq(requestContext.getDBName()));
+    }
+
+    @Test
+    public void testMetricsRegistryForRequestToCollection() {
+        RequestContext requestContext = createRequestContext(URI_METRICS_COLLECTION);
+        handler.getMetricsRegistry(requestContext, COLLECTION);
+        verify(handler.metrics, times(1)).registry(eq(requestContext.getDBName()), eq(requestContext.getCollectionName()));
+    }
+
+    private RequestContext createRequestContext(String requestUri) {
+        HttpServerExchange httpServerExchange1 = mock(HttpServerExchange.class);
+        when(httpServerExchange1.getStatusCode()).thenReturn(200);
+        when(httpServerExchange1.getRequestMethod()).thenReturn(Methods.GET);
+        when(httpServerExchange1.getRequestPath()).thenReturn("/");
+        HttpServerExchange httpServerExchange = httpServerExchange1;
+        return new RequestContext(httpServerExchange, "/", requestUri);
     }
 }


### PR DESCRIPTION
I've changed the way prometheus metrics are returned, only if queried via /_metrics. In this case the metrics contain all gathered values including database and collection labels. This allows to create e.g. grafana dashboards on database and/or collection level using a single metrics endpoint only. The JSON metrics format hasn't changed at all!