### PR TITLE
removing trace headers from thread local MDC after call is done

### DIFF
--- a/src/main/java/org/restheart/handlers/metrics/TracingInstrumentationHandler.java
+++ b/src/main/java/org/restheart/handlers/metrics/TracingInstrumentationHandler.java
@@ -33,5 +33,9 @@ public class TracingInstrumentationHandler extends PipedHttpHandler {
         if (!exchange.isResponseComplete() && getNext() != null) {
             next(exchange, context);
         }
+
+        for (String traceIdHeader : Bootstrapper.getConfiguration().getTraceHeaders()) {
+            MDC.remove(traceIdHeader);
+        }
     }
 }


### PR DESCRIPTION
Restheart trace header logging currently does not remove trace headers from MDC - I forgot about this in the initial proposal, since we never had calls without trace headers.

I just have seen it for metrics and health check requests (threads are being re-used between health check calls or metrics calls, those do not have trace headers sent). Whenever you send a request with a trace id, and a health check call afterwards, the health check call will log the same trace id.

I have not tested the proposal so far, but will most probably do so in the next days.

However, since I have seen that restheart-security currently does not log trace headers at all, I thought I give you this hint as early as possible, together with the idea to include this trace header logging in restheart-security as well ;).