### PR TITLE
Integration tests for ACL predicates

### DIFF
--- a/core/etc/test/acl.yml
+++ b/core/etc/test/acl.yml
@@ -93,7 +93,9 @@ permissions:
         allowBulkDelete: true         # default false
         allowWriteMode: true          # default false
 
-  - role: testQParams
+
+
+  - role: test
     # qparams-whitelist() === qparams-size(0)
     predicate: >
       method(GET)
@@ -104,19 +106,61 @@ permissions:
     priority: 0
 
 
-  - role : testQParams
+
+  - role : test
     predicate: >
       method(GET) 
       and qparams-whitelist(rep)
       and path-prefix[path="/test-predicates/coll"]
-      
-    priority: 0
+    mongo:
+      projectResponse: >
+        {"log": 0}
+    priority: 100
 
-  - role: testQParams
+
+
+  - role : test
+    predicate: >
+      method(GET) 
+      and qparams-whitelist(rep)
+      and path-template(value="/test-predicates/coll/{id}")
+    priority: 100
+
+
+
+  - role: test
     predicate: >
       method(POST)
       and bson-request-contains(title)
       and bson-request-whitelist(title, content)
       and path-prefix[path="/test-predicates/coll"]
-    priority: 0
+    mongo:
+      mergeRequest: >
+        {"author": "@user.userid", "status": "draft", "log": "@request"}
+    priority: 100
+
+
+  # projectResponse
+
+  - role : test
+    predicate: >
+      method(GET)
+      and path-prefix[path="/test-predicates/projectResponse"]
+    mongo:
+      projectResponse: >
+        {"user": 1}
+    priority: 100
+
+
+  - role : test
+    predicate: >
+      method(POST)
+      and path-prefix[path="/test-predicates/projectResponse"]
+    mongo:
+      mergeRequest: >
+        {"user" : "@user.userid"}
+    priority: 100
+
+
+
 

--- a/core/etc/test/acl.yml
+++ b/core/etc/test/acl.yml
@@ -92,3 +92,31 @@ permissions:
         allowBulkPatch: true          # default false
         allowBulkDelete: true         # default false
         allowWriteMode: true          # default false
+
+  - role: testQParams
+    # qparams-whitelist() === qparams-size(0)
+    predicate: >
+      method(GET)
+      and qparams-size(2)
+      and qparams-blacklist(size)
+      and qparams-whitelist(filter, page, q1)
+      and path[path="/secho"]
+    priority: 0
+
+
+  - role : testQParams
+    predicate: >
+      method(GET) 
+      and qparams-whitelist(rep)
+      and path-prefix[path="/test-predicates/coll"]
+      
+    priority: 0
+
+  - role: testQParams
+    predicate: >
+      method(POST)
+      and bson-request-contains(title)
+      and bson-request-whitelist(title, content)
+      and path-prefix[path="/test-predicates/coll"]
+    priority: 0
+

--- a/core/etc/test/users.yml
+++ b/core/etc/test/users.yml
@@ -7,7 +7,7 @@ users:
 
     - userid: test
       password: secret
-      roles: [ testQParams ]
+      roles: [ test ]
 
     - userid: user1
       password: secret

--- a/core/etc/test/users.yml
+++ b/core/etc/test/users.yml
@@ -5,6 +5,10 @@ users:
       password: secret
       roles: [user, admin]
 
+    - userid: test
+      password: secret
+      roles: [ testQParams ]
+
     - userid: user1
       password: secret
       roles: [poweruser]

--- a/core/src/test/java/karate/RunnerIT.java
+++ b/core/src/test/java/karate/RunnerIT.java
@@ -36,7 +36,7 @@ public class RunnerIT extends AbstactIT {
     @Test
     public void run() {
         var results = Runner.path("classpath:karate")
-                .tags("~@ignore")
+                .tags("~@ignore", "@onlyme")
                 .parallel(1);
 
         assertEquals(0, results.getFailCount());

--- a/core/src/test/java/karate/RunnerIT.java
+++ b/core/src/test/java/karate/RunnerIT.java
@@ -36,7 +36,7 @@ public class RunnerIT extends AbstactIT {
     @Test
     public void run() {
         var results = Runner.path("classpath:karate")
-                .tags("~@ignore", "@onlyme")
+                .tags("~@ignore")
                 .parallel(1);
 
         assertEquals(0, results.getFailCount());

--- a/core/src/test/java/karate/predicate-acl-cleanup.feature
+++ b/core/src/test/java/karate/predicate-acl-cleanup.feature
@@ -1,0 +1,27 @@
+@ignore
+Feature: Clean up data for predicat-acl
+
+
+Background: 
+
+ * url 'http://localhost:8080'
+  * def basic =
+  """
+  function(creds) {
+  var temp = creds.username + ':' + creds.password;
+  var Base64 = Java.type('java.util.Base64');
+  var encoded = Base64.getEncoder().encodeToString(temp.toString().getBytes());
+  return 'Basic ' + encoded;
+  }
+  """
+
+  * def admin = basic({username: 'admin', password: 'secret'})
+
+Scenario:
+
+  # delete database test-predicates
+  * headers { "Authorization" : '#(admin)', 'If-Match': '#(ETag)' }
+  Given path '/test-predicates'
+  And param filter = '{"_id":{"$exists":true}}'
+  When method DELETE
+  And status 204

--- a/core/src/test/java/karate/predicate-acl-setup.feature
+++ b/core/src/test/java/karate/predicate-acl-setup.feature
@@ -1,0 +1,35 @@
+@ignore
+Feature: Prepare test data for predicates-acl feature
+
+
+Background:
+  * url 'http://localhost:8080'
+  * def basic =
+  """
+  function(creds) {
+  var temp = creds.username + ':' + creds.password;
+  var Base64 = Java.type('java.util.Base64');
+  var encoded = Base64.getEncoder().encodeToString(temp.toString().getBytes());
+  return 'Basic ' + encoded;
+  }
+  """
+
+  * def admin = basic({username: 'admin', password: 'secret'})
+
+Scenario: Create db and collection
+
+  # create db test-predicates
+  * header Authorization = admin
+  Given path '/test-predicates'
+  When method PUT
+  Then status 201
+  * def ETag = responseHeaders['ETag'][0]
+
+
+  # create coll collection
+  * header Authorization = admin
+  Given path 'test-predicates/coll'
+  When method PUT
+  Then status 201
+
+

--- a/core/src/test/java/karate/predicate-acl-setup.feature
+++ b/core/src/test/java/karate/predicate-acl-setup.feature
@@ -33,3 +33,11 @@ Scenario: Create db and collection
   Then status 201
 
 
+  # create projectResponse collection
+  * header Authorization = admin
+  Given path 'test-predicates/projectResponse'
+  When method PUT
+  Then status 201
+
+
+

--- a/core/src/test/java/karate/predicates-acl.feature
+++ b/core/src/test/java/karate/predicates-acl.feature
@@ -1,0 +1,96 @@
+@onlyme
+Feature: Test predicates in acl
+  
+Background:
+  * url 'http://localhost:8080'
+  * def basic =
+  """
+  function(creds) {
+  var temp = creds.username + ':' + creds.password;
+  var Base64 = Java.type('java.util.Base64');
+  var encoded = Base64.getEncoder().encodeToString(temp.toString().getBytes());
+  return 'Basic ' + encoded;
+  }
+  """
+  * def test = basic({username: 'test', password: 'secret' })
+  * def admin = basic({username: 'admin', password: 'secret'})
+
+Scenario: Test qparams-size(2)
+
+  * header Authorization = test 
+  Given path '/secho'
+  * params { filter: "param2", page: 2 }
+  When method GET
+  Then status 200
+
+  # must fail, qparams size != 2
+  * header Authorization = test 
+  Given path '/secho'
+  * params { filter: "param1" }
+  When method GET
+  Then status 403
+
+Scenario: Test qparams-blacklist(size)
+
+  * header Authorization = test 
+  Given path '/secho'
+  * params { filter: "param1", q1: "param2" }
+  When method GET
+  Then status 200
+
+
+  * header Authorization = test 
+  Given path '/secho'
+  * params { filter: "param1", size: "param2" }
+  When method GET
+  Then status 403
+
+Scenario: Test qparams-whitelist(filter)
+
+  * header Authorization = test 
+  Given path '/secho'
+  * params { filter: "param1", q1: "2" }
+  When method GET
+  Then status 200
+
+
+Scenario: Test bson-request-contains, request must contain specified keys in acl
+
+  * def setupData = call read('predicate-acl-setup.feature')
+
+  * print "After setup data"
+
+  * print setupData.ETag
+
+  * print "last print"
+
+  # valid request
+  * header Authorization = test
+  Given path 'test-predicates/coll'
+  And request { title: "Valid predicate" }
+  When method POST
+  Then status 201
+
+  # valid request
+  * header Authorization = test
+  Given path 'test-predicates/coll'
+  And request { title: "predicates", content: "Testing valid request" }
+  When method POST
+  Then status 201
+
+  # "example" keys is now allowed > 403
+  * header Authorization = test
+  Given path 'test-predicates/coll'
+  And request { example: "Hello" }
+  When method POST
+  Then status 403
+
+  # "example" and "test" keys are now allowed > 403
+  * header Authorization = test
+  Given path 'test-predicates/coll'
+  And request { example: "Hello", test: "test value" }
+  When method POST
+  Then status 403
+
+  And call read('predicate-acl-cleanup.feature') { ETag: '#(setupData.ETag)' }
+

--- a/core/src/test/java/karate/predicates-acl.feature
+++ b/core/src/test/java/karate/predicates-acl.feature
@@ -1,4 +1,3 @@
-@onlyme
 Feature: Test predicates in acl
   
 Background:

--- a/core/src/test/java/karate/predicates-acl.feature
+++ b/core/src/test/java/karate/predicates-acl.feature
@@ -53,7 +53,7 @@ Scenario: Test qparams-whitelist(filter)
   Then status 200
 
 # allowed keys are "title" and "content". Every request must contain "title" key
-Scenario: Test bson-request-contains, request must contain specified keys in acl
+Scenario: Test bson-request-contains and bson-request-whitelist
 
   * def setupData = call read('predicate-acl-setup.feature')
 


### PR DESCRIPTION
Integration tests for the following predicates
- qparams-contain
- qparams-blacklist
- qparams-whitelist
- bson-request-whitelist
- bson-request-contains
- mongo mergeRequest
- mong projectResponse