### PR TITLE
fix: decode URL-encoded slashes in document IDs

### DIFF
--- a/commons/src/main/java/org/restheart/exchange/MongoRequest.java
+++ b/commons/src/main/java/org/restheart/exchange/MongoRequest.java
@@ -716,7 +716,17 @@ public class MongoRequest extends BsonRequest {
      * @return document id
      */
     public String getDocumentIdRaw() {
-        return getPathTokenAt(3);
+        String _docId = getPathTokenAt(3);
+
+        if (_docId == null) {
+            return null;
+        }
+
+        // Decode encoded slashes (%2F / %2f) in document ID
+        // Do NOT use URI decoding here — the document ID is already decoded except for slashes
+        _docId = _docId.replace("%2F", "/").replace("%2f", "/");
+
+        return _docId;
     }
 
     /**


### PR DESCRIPTION
This pull request updates the logic for extracting the document ID from the request path in the `MongoRequest` class. The main improvement is to correctly handle encoded slashes in document IDs, ensuring that document IDs containing slashes are interpreted as intended.

Enhancement to document ID extraction:

* Updated the `getDocumentIdRaw()` method in `MongoRequest.java` to decode encoded slashes (`%2F` and `%2f`) in the document ID, while avoiding full URI decoding since other characters are already decoded.