### PR TITLE
Helm chart add support for RESTHeart v9.x

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "6.6.1"
+appVersion: "9.2.0"

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -13,10 +13,14 @@ spec:
       {{- include "restheart.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- if or (not .Values.useExternalConfig) .Values.podAnnotations }}
       annotations:
+        {{- if not .Values.useExternalConfig }}
         checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- end }}
       labels:
         {{- include "restheart.selectorLabels" . | nindent 8 }}
@@ -66,9 +70,18 @@ spec:
               mountPath: /opt/restheart/etc/restheart.yml
               subPath: restheart.yml
       volumes:
+        {{- if .Values.useExternalConfig }}
+        - name: configuration
+          secret:
+            secretName: {{ required "externalConfig.name is required when useExternalConfig=true" .Values.externalConfig.name }}
+            items:
+              - key: {{ .Values.externalConfig.key | quote }}
+                path: restheart.yml
+        {{- else }}
         - name: configuration
           secret:
             secretName: {{ include "restheart.fullname" . }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -34,15 +34,18 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.containerCommand }}
           command:
-            - "java"
-            - "-Dfile.encoding=UTF-8"
-            - "-server"
-            - "-jar"
-            - "restheart.jar"
-            - "etc/restheart.yml"
-            - "--envFile"
-            - "etc/default.properties"
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.containerArgs }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.env }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -33,7 +33,7 @@ spec:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
-      secretName: {{ .secretName }}
+      secretName: {{ .secretName | default (printf "%s-resthart-tls" (include "restheart.fullname" $)) }}
     {{- end }}
   {{- end }}
   rules:

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -33,7 +33,7 @@ spec:
         {{- range .hosts }}
         - {{ . | quote }}
         {{- end }}
-      secretName: {{ .secretName | default (printf "%s-resthart-tls" (include "restheart.fullname" $)) }}
+      secretName: {{ .secretName | default (printf "%s-restheart-tls" (include "restheart.fullname" $)) }}
     {{- end }}
   {{- end }}
   rules:

--- a/chart/templates/secret.yaml
+++ b/chart/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.useExternalConfig -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,3 +7,4 @@ metadata:
     {{- include "restheart.labels" . | nindent 4 }}
 data:
   restheart.yml: {{ .Values.restHeartConfiguration | toYaml | b64enc }}
+{{- end -}}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -10,6 +10,23 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+# Optional explicit container command/args override.
+# By default, chart uses the Docker image ENTRYPOINT/CMD.
+# Example for forcing JVM mode:
+# containerCommand: ["java", "-Dfile.encoding=UTF-8", "-server", "-jar", "restheart.jar", "etc/restheart.yml", "--envFile", "etc/default.properties"]
+# containerArgs: ["etc/restheart.yml"]
+containerCommand: []
+containerArgs:
+  - "etc/restheart.yml"
+
+# Environment variables for RESTHeart container.
+# IMPORTANT: the official image defines a default RHO that overrides config options
+# (for example mclient/connection-string). We set RHO to empty by default so
+# restHeartConfiguration from values is used as-is.
+env:
+  - name: RHO
+    value: ""
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -96,6 +96,16 @@ podDisruptionBudget:
   minAvailable: 1
   maxUnavailable: ""
 
+# Config source for /opt/restheart/etc/restheart.yml
+# false (default): use generated Secret from restHeartConfiguration
+# true: mount external Secret key as restheart.yml
+useExternalConfig: false
+externalConfig:
+  # Required when useExternalConfig=true
+  name: ""
+  # Key in external Secret that contains RESTHeart config
+  key: "restheart.yml"
+
 # reastheart.yml file.
 # At least you should configure options:
 # - instance-base-url - to configure public URL when it is run behind reverse proxy.


### PR DESCRIPTION
This PR:

-  Add support for customizable container command, arguments, and environment variables in deployment (support for images with **native** tag)
-  Add support for external configuration by introducing useExternalConfig option and updating deployment and secret templates (backward compatibility for v8 and capability for new config file for v9)
- Set default secretName for TLS configuration in ingress template, if is not defined
- Update chart version to 0.1.1 and appVersion to 9.2.0