### PR TITLE
feat: add MongoDB client metadata

### DIFF
--- a/mongoclient/src/main/java/org/restheart/mongodb/MongoClientSingleton.java
+++ b/mongoclient/src/main/java/org/restheart/mongodb/MongoClientSingleton.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import com.mongodb.ConnectionString;
 import com.mongodb.MongoClientSettings;
+import com.mongodb.MongoDriverInformation;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.connection.ConnectionPoolSettings;
@@ -49,6 +50,11 @@ public class MongoClientSingleton {
     private String serverVersion = null;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MongoClientSingleton.class);
+
+    private static final MongoDriverInformation DRIVER_INFO = MongoDriverInformation.builder()
+            .driverName("RESTHeart")
+            .driverVersion(org.restheart.configuration.Configuration.VERSION)
+            .build();
 
     /**
      *
@@ -115,7 +121,7 @@ public class MongoClientSingleton {
                 .applyConnectionString(mongoUri)
                 .build();
 
-        mclient = MongoClients.create(settings);
+        mclient = MongoClients.create(settings, DRIVER_INFO);
 
         // this is the first time we check the connection
         if (connected(mclient)) {


### PR DESCRIPTION
The PR incorporates MongoDB's [wrapping client library](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md#supporting-wrapping-libraries) specification for the connection handshake to allow library details to be included in the metadata written to `mongos` or `mongod` logs.

For example, this change would allow server-side logs such as the following:

> {"t":{"$date":"2026-04-20T11:33:05.688+00:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn70990","msg":"client metadata","attr":{"remote":"192.168.0.1:34567","client":"conn70990","negotiatedCompressors":["zstd"],"doc":{"application":{"name":"my-api-app"},`"driver":{"name":"mongo-java-driver|RESTHeart"`,"version":"5.0.0|9.0.0"},"os":{"type":"Linux","name":"Linux","architecture":"amd64","version":"6.1.119-129.201.amzn2023.x86_64"},"platform":"Java/Amazon.com Inc./21.0.8+9-LTS"}}}

For anyone hosting clusters with connections coming from different applications this can help differentiate connections and facilitate log analysis.

This is effectively the same approach taken by Spring Data MongoDB (see [SpringDataMongoDB.java](https://github.com/spring-projects/spring-data-mongodb/blob/main/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/SpringDataMongoDB.java#L37-L47), [AbstractMongoClientConfiguration.java](https://github.com/spring-projects/spring-data-mongodb/blob/024d49d4df7cba4eb970cbbd651416742fe1bebf/spring-data-mongodb/src/main/java/org/springframework/data/mongodb/config/AbstractMongoClientConfiguration.java#L107-L109)), and just [added to Morphia](https://github.com/MorphiaOrg/morphia/pull/4230).