### PR TITLE
feat: MQTT client module phase 1

### DIFF
--- a/mqtt/pom.xml
+++ b/mqtt/pom.xml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>restheart-parent</artifactId>
+    <groupId>org.restheart</groupId>
+    <version>10.0.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.restheart</groupId>
+  <artifactId>restheart-mqtt</artifactId>
+  <packaging>jar</packaging>
+
+  <name>restheart-mqtt</name>
+  <description>RESTHeart MQTT - MQTT Client Provider and Services</description>
+  <url>http://www.restheart.org</url>
+  <inceptionYear>2026</inceptionYear>
+
+  <licenses>
+    <license>
+      <name>GNU Affero General Public License (AGPL) version 3.0</name>
+      <url>http://www.gnu.org/licenses/agpl-3.0.html</url>
+      <distribution>repo</distribution>
+      <comments>Core components license</comments>
+    </license>
+  </licenses>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.restheart</groupId>
+      <artifactId>restheart-commons</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.hivemq</groupId>
+      <artifactId>hivemq-mqtt-client</artifactId>
+      <version>1.3.13</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>mongodb-driver-sync</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <!-- BEGIN Test dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.moquette</groupId>
+      <artifactId>moquette-broker</artifactId>
+      <version>0.17</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- END Test dependencies -->
+  </dependencies>
+
+  <build>
+    <finalName>${project.artifactId}</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+            <execution>
+            <id>copy-dependencies</id>
+            <phase>prepare-package</phase>
+            <goals>
+                <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+                <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                <includeScope>runtime</includeScope>
+            </configuration>
+            </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <verbose>true</verbose>
+          <includes>
+            <includes>*/.java</includes>
+          </includes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>generate-license-headers</id>
+            <goals>
+              <goal>update-file-header</goal>
+            </goals>
+            <phase>process-sources</phase>
+            <configuration>
+              <licenseName>agpl_v3</licenseName>
+              <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
+              <emptyLineAfterHeader>true</emptyLineAfterHeader>
+              <skipUpdateLicense>${skipUpdateLicense}</skipUpdateLicense>
+              <processStartTag>========================LICENSE_START=================================</processStartTag>
+              <processEndTag>=========================LICENSE_END==================================</processEndTag>
+              <roots>
+                <root>src/main/java</root>
+              </roots>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-Xlint:-removal</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/mqtt/pom.xml
+++ b/mqtt/pom.xml
@@ -5,6 +5,7 @@
     <artifactId>restheart-parent</artifactId>
     <groupId>org.restheart</groupId>
     <version>10.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
   </parent>
 
   <groupId>org.restheart</groupId>

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttClientProvider.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttClientProvider.java
@@ -96,43 +96,46 @@ public class MqttClientProvider implements Provider<MqttClient>{
 
         // Reconnect configuration
         @SuppressWarnings("unchecked")
-        final Map<String, Object> reconnectConfig = (Map<String, Object>) config.get("reconnect");
-        final boolean reconnectEnabled = reconnectConfig != null ? argOrDefault(reconnectConfig, "enabled", true) : true;
-        final long initialDelayMs = reconnectConfig != null ? argOrDefault(reconnectConfig, "initial-delay-ms", 1000L) : 1000L;
-        final long maxDelayMs = reconnectConfig != null ? argOrDefault(reconnectConfig, "max-delay-ms", 30000L) : 30000L;
+        final Map<String, Object> reconnectConfigMap = (Map<String, Object>) config.get("reconnect");
+        final boolean reconnectEnabled = argOrDefault(reconnectConfigMap, "enabled", true);
+        final long initialDelayMs = argOrDefault(reconnectConfigMap, "initial-delay-ms", 1000L);
+        final long maxDelayMs = argOrDefault(reconnectConfigMap, "max-delay-ms", 30000L);
 
         // Will message configuration
         @SuppressWarnings("unchecked")
-        final Map<String, Object> willConfig = (Map<String, Object>) config.get("will");
-        final String willTopic = willConfig != null ? argOrDefault(willConfig, "topic", null) : null;
-        final String willPayload = willConfig != null ? argOrDefault(willConfig, "payload", null) : null;
-        final int willQos = willConfig != null ? argOrDefault(willConfig, "qos", 0) : 0;
-        final boolean willRetain = willConfig != null ? argOrDefault(willConfig, "retain", false) : false;
-        final long willDelaySeconds = willConfig != null ? argOrDefault(willConfig, "delay-seconds", 0L) : 0L;
-        final Long willMessageExpirySeconds = willConfig != null ? argOrDefault(willConfig, "message-expiry-seconds", null) :null;
+        final Map<String, Object> willConfigMap = (Map<String, Object>) config.get("will");
+        final String willTopic = argOrDefault(willConfigMap, "topic", null);
+        final String willPayload = argOrDefault(willConfigMap, "payload", null);
+        final int willQos = argOrDefault(willConfigMap, "qos", 0);
+        final boolean willRetain = argOrDefault(willConfigMap, "retain", false);
+        final long willDelaySeconds = argOrDefault(willConfigMap, "delay-seconds", 0L);
+        final Long willMessageExpirySeconds = argOrDefault(willConfigMap, "message-expiry-seconds", null);
+
+        // Build configuration objects
+        MqttConfig.ReconnectConfig reconnectConfig= new MqttConfig.ReconnectConfig(
+            reconnectEnabled, 
+            initialDelayMs, 
+            maxDelayMs);
+
+        MqttConfig.WillConfig willConfig = new MqttConfig.WillConfig(willTopic, willPayload, willQos, willRetain, willDelaySeconds, willMessageExpirySeconds);
+
+        MqttConfig mqttConfig = new MqttConfig.Builder()
+            .brokerUrl(brokerUrl)
+            .protocolVersion(protocolVersion)
+            .clientId(clientId)
+            .username(username)
+            .password(password)
+            .cleanSession(cleanSession)
+            .keepAliveSeconds(keepAliveSeconds)
+            .sessionExpirySeconds(sessionExpirySeconds)
+            .connectTimeoutSeconds(connectTimeoutSeconds)
+            .tlsEnabled(tlsEnabled)
+            .reconnectConfig(reconnectConfig)
+            .willConfig(willConfig)
+            .build();
 
         // Initialize the singleton with configuration
-        MqttClientSingleton.init(
-            brokerUrl,
-            protocolVersion,
-            clientId,
-            username,
-            password,
-            cleanSession,
-            keepAliveSeconds,
-            sessionExpirySeconds,
-            connectTimeoutSeconds,
-            tlsEnabled,
-            reconnectEnabled,
-            initialDelayMs,
-            maxDelayMs,
-            willTopic,
-            willPayload,
-            willQos,
-            willRetain,
-            willDelaySeconds,
-            willMessageExpirySeconds
-        );
+        MqttClientSingleton.init(mqttConfig);
 
         // Force first connection to MQTT broker
         MqttClientSingleton.getInstance().connect();

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttClientProvider.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttClientProvider.java
@@ -1,0 +1,132 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-mongoclient-provider
+ * %%
+ * Copyright (C) 2014 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+package org.restheart.mqtt;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.restheart.plugins.Inject;
+import org.restheart.plugins.OnInit;
+import org.restheart.plugins.PluginRecord;
+import org.restheart.plugins.Provider;
+import org.restheart.plugins.RegisterPlugin;
+
+import com.hivemq.client.mqtt.MqttClient;
+
+/**
+ * RESTHeart provider plugin that supplies a configured and connected HiveMQ {@link MqttClient}.
+ * <p>
+ * This provider extracts MQTT configuration options from RESTHeart configuration,
+ * initializes the {@link MqttClientSingleton}, and triggers the initial connection to the MQTT broker.
+ * </p>
+ *
+ * @see Provider
+ * @see MqttClient
+ * @see MqttClientSingleton
+ */
+@RegisterPlugin(
+    name = "mqtt-client",
+    description = "Provides a connected MQTT client",
+    priority = 10
+)
+public class MqttClientProvider implements Provider<MqttClient>{
+    
+    /**
+     * Configuration map containing properties for the MQTT client plugin,
+     * injected automatically by RESTHeart.
+     */
+    @Inject("config")
+    private Map<String, Object> config;
+
+    /**
+     * Initializes the MQTT client configuration, sets default values for missing configuration keys,
+     * configures the {@link MqttClientSingleton}, and establishes the initial connection to the broker.
+     * <p>
+     * Supported configuration keys in the {@code config} map:
+     * <ul>
+     *   <li>{@code broker-url} - The broker endpoint URL (default: "tcp://localhost:1883")</li>
+     *   <li>{@code protocol-version} - MQTT version, 3 or 5 (default: 3)</li>
+     *   <li>{@code client-id} - Identifier for the MQTT client (default: "restheart-" + random UUID)</li>
+     *   <li>{@code username} - Username for broker authentication (default: null)</li>
+     *   <li>{@code password} - Password for broker authentication (default: null)</li>
+     *   <li>{@code clean-session} - Whether to discard session state on connection (default: true)</li>
+     *   <li>{@code keep-alive-seconds} - Keep-alive time interval (default: 60)</li>
+     *   <li>{@code connect-timeout-seconds} - Timeout for establishing connection (default: 10)</li>
+     *   <li>{@code tls} - Enable SSL/TLS encryption (default: false)</li>
+     *   <li>{@code session-expiry-seconds} - Session expiry interval (default: 0)</li>
+     *   <li>{@code reconnect/enabled} - Enable automatic reconnect (default: true)</li>
+     *   <li>{@code reconnect/initial-delay-ms} - Reconnect initial delay in ms (default: 1000)</li>
+     *   <li>{@code reconnect/max-delay-ms} - Reconnect max delay in ms (default: 30000)</li>
+     * </ul>
+     * </p>
+     */
+    @OnInit
+    public void init() {
+        final String brokerUrl = argOrDefault(config, "broker-url", "tcp://localhost:1883");
+        final int protocolVersion = argOrDefault(config, "protocol-version", 3);
+        final String clientId = argOrDefault(config, "client-id", "restheart-" + UUID.randomUUID().toString());
+        final String username = argOrDefault(config, "username", null);
+        final String password = argOrDefault(config, "password", null);
+        final boolean cleanSession = argOrDefault(config, "clean-session", true);
+        final int keepAliveSeconds = argOrDefault(config, "keep-alive-seconds", 60);
+        final int connectTimeoutSeconds = argOrDefault(config, "connect-timeout-seconds", 10);
+        final boolean tlsEnabled = argOrDefault(config, "tls", false);
+
+        final long sessionExpirySeconds = argOrDefault(config, "session-expiry-seconds", 0xFFFFFFFF);
+
+        // Reconnect configuration
+        final boolean reconnectEnabled = argOrDefault(config, "reconnect/enabled", true);
+        final long initialDelayMs = argOrDefault(config, "reconnect/initial-delay-ms", 1000L);
+        final long maxDelayMs = argOrDefault(config, "reconnect/max-delay-ms", 30000L);
+
+        // Initialize the singleton with configuration
+        MqttClientSingleton.init(
+            brokerUrl,
+            protocolVersion,
+            clientId,
+            username,
+            password,
+            cleanSession,
+            keepAliveSeconds,
+            sessionExpirySeconds,
+            connectTimeoutSeconds,
+            tlsEnabled,
+            reconnectEnabled,
+            initialDelayMs,
+            maxDelayMs
+        );
+
+        // Force first connection to MQTT broker
+        MqttClientSingleton.getInstance().connect();
+    }
+
+    /**
+     * Returns the singleton {@link MqttClient} instance.
+     *
+     * @param caller the plugin record representing the caller requesting the client
+     * @return the configured and connected {@link MqttClient} instance
+     */
+    @Override
+    public MqttClient get(final PluginRecord<?> caller) {
+        return MqttClientSingleton.get().getClient();
+    }
+    
+}

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttClientProvider.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttClientProvider.java
@@ -41,6 +41,8 @@ import com.hivemq.client.mqtt.MqttClient;
  * @see Provider
  * @see MqttClient
  * @see MqttClientSingleton
+ * 
+ * @author Harshit Sharma {@literal <harshitsharma635@gmail.com>}
  */
 @RegisterPlugin(
     name = "mqtt-client",
@@ -97,6 +99,14 @@ public class MqttClientProvider implements Provider<MqttClient>{
         final long initialDelayMs = argOrDefault(config, "reconnect/initial-delay-ms", 1000L);
         final long maxDelayMs = argOrDefault(config, "reconnect/max-delay-ms", 30000L);
 
+        // Will message configuration
+        final String willTopic = argOrDefault(config, "will/topic", null);
+        final String willPayload = argOrDefault(config, "will/payload", null);
+        final int willQos = argOrDefault(config, "will/qos", 0);
+        final boolean willRetain = argOrDefault(config, "will/retain", false);
+        final long willDelaySeconds = argOrDefault(config, "will/delay-seconds", 0L);
+        final Long willMessageExpirySeconds = argOrDefault(config, "will/message-expiry-seconds", null);
+
         // Initialize the singleton with configuration
         MqttClientSingleton.init(
             brokerUrl,
@@ -111,7 +121,13 @@ public class MqttClientProvider implements Provider<MqttClient>{
             tlsEnabled,
             reconnectEnabled,
             initialDelayMs,
-            maxDelayMs
+            maxDelayMs,
+            willTopic,
+            willPayload,
+            willQos,
+            willRetain,
+            willDelaySeconds,
+            willMessageExpirySeconds
         );
 
         // Force first connection to MQTT broker

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttClientProvider.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttClientProvider.java
@@ -95,17 +95,21 @@ public class MqttClientProvider implements Provider<MqttClient>{
         final long sessionExpirySeconds = argOrDefault(config, "session-expiry-seconds", 0xFFFFFFFFL);
 
         // Reconnect configuration
-        final boolean reconnectEnabled = argOrDefault(config, "reconnect/enabled", true);
-        final long initialDelayMs = argOrDefault(config, "reconnect/initial-delay-ms", 1000L);
-        final long maxDelayMs = argOrDefault(config, "reconnect/max-delay-ms", 30000L);
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> reconnectConfig = (Map<String, Object>) config.get("reconnect");
+        final boolean reconnectEnabled = reconnectConfig != null ? argOrDefault(reconnectConfig, "enabled", true) : true;
+        final long initialDelayMs = reconnectConfig != null ? argOrDefault(reconnectConfig, "initial-delay-ms", 1000L) : 1000L;
+        final long maxDelayMs = reconnectConfig != null ? argOrDefault(reconnectConfig, "max-delay-ms", 30000L) : 30000L;
 
         // Will message configuration
-        final String willTopic = argOrDefault(config, "will/topic", null);
-        final String willPayload = argOrDefault(config, "will/payload", null);
-        final int willQos = argOrDefault(config, "will/qos", 0);
-        final boolean willRetain = argOrDefault(config, "will/retain", false);
-        final long willDelaySeconds = argOrDefault(config, "will/delay-seconds", 0L);
-        final Long willMessageExpirySeconds = argOrDefault(config, "will/message-expiry-seconds", null);
+        @SuppressWarnings("unchecked")
+        final Map<String, Object> willConfig = (Map<String, Object>) config.get("will");
+        final String willTopic = willConfig != null ? argOrDefault(willConfig, "topic", null) : null;
+        final String willPayload = willConfig != null ? argOrDefault(willConfig, "payload", null) : null;
+        final int willQos = willConfig != null ? argOrDefault(willConfig, "qos", 0) : 0;
+        final boolean willRetain = willConfig != null ? argOrDefault(willConfig, "retain", false) : false;
+        final long willDelaySeconds = willConfig != null ? argOrDefault(willConfig, "delay-seconds", 0L) : 0L;
+        final Long willMessageExpirySeconds = willConfig != null ? argOrDefault(willConfig, "message-expiry-seconds", null) :null;
 
         // Initialize the singleton with configuration
         MqttClientSingleton.init(

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttClientProvider.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttClientProvider.java
@@ -87,12 +87,12 @@ public class MqttClientProvider implements Provider<MqttClient>{
         final String clientId = argOrDefault(config, "client-id", "restheart-" + UUID.randomUUID().toString());
         final String username = argOrDefault(config, "username", null);
         final String password = argOrDefault(config, "password", null);
-        final boolean cleanSession = argOrDefault(config, "clean-session", true);
+        final boolean cleanSession = argOrDefault(config, "clean-session", false);
         final int keepAliveSeconds = argOrDefault(config, "keep-alive-seconds", 60);
         final int connectTimeoutSeconds = argOrDefault(config, "connect-timeout-seconds", 10);
         final boolean tlsEnabled = argOrDefault(config, "tls", false);
 
-        final long sessionExpirySeconds = argOrDefault(config, "session-expiry-seconds", 0xFFFFFFFF);
+        final long sessionExpirySeconds = argOrDefault(config, "session-expiry-seconds", 0xFFFFFFFFL);
 
         // Reconnect configuration
         final boolean reconnectEnabled = argOrDefault(config, "reconnect/enabled", true);

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttClientSingleton.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttClientSingleton.java
@@ -41,7 +41,7 @@ import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientBuilder;
 
 /**
- * Thread-safe singleton that manages the lifecycle of a MQTT clien=t  {@link MqttClient}.
+ * Thread-safe singleton that manages the lifecycle of a MQTT client  {@link MqttClient}.
  * <p>
  * This singleton can be configured to use either MQTT v3 or MQTT v5 protocols.
  * It provides features such as automatic reconnection, authentication (username/password),
@@ -107,67 +107,33 @@ public class MqttClientSingleton {
     /**
      * Initializes the MQTT client singleton with the specified configuration parameters.
      *
-     * @param brokerUrl                the broker endpoint URL
-     * @param protocolVersion          the MQTT protocol version (3 or 5)
-     * @param clientId                 the unique identifier for the client
-     * @param username                 the username for authentication (can be null)
-     * @param password                 the password for authentication (can be null)
-     * @param cleanSession             whether to clear session state on connection
-     * @param keepAliveSeconds         the keep-alive interval in seconds
-     * @param sessionExpirySeconds     the session expiry interval in seconds (MQTT v5 only)
-     * @param connectTimeoutSeconds    the connection timeout in seconds
-     * @param tlsEnabled               whether TLS/SSL should be enabled
-     * @param reconnectEnabled         whether automatic reconnection should be enabled
-     * @param initialDelayMs           the initial delay in milliseconds for reconnection
-     * @param maxDelayMs               the maximum delay in milliseconds for reconnection
-     * @param willTopic                the will message topic (can be null)
-     * @param willPayload              the will message payload (can be null)
-     * @param willQos                  the will message QoS level (0,1, or 2)
-     * @param willRetain               whether the will message should be retained
-     * @param willDelaySeconds         the will delay interval in seconds (MQTT v5 only)
-     * @param willMessageExpirySeconds the will message expiry interval in seconds (MQTT v5 only)
+     * @param config the MQTT configuration containing all connection parameters
      */
-    public static void init(
-            String brokerUrl,
-            int protocolVersion,
-            String clientId,
-            String username,
-            String password,
-            boolean cleanSession,
-            int keepAliveSeconds,
-            long sessionExpirySeconds,
-            int connectTimeoutSeconds,
-            boolean tlsEnabled,
-            boolean reconnectEnabled,
-            long initialDelayMs,
-            long maxDelayMs,
-            String willTopic,
-            String willPayload,
-            int willQos,
-            boolean willRetain,
-            long willDelaySeconds,
-            Long willMessageExpirySeconds) {
+    public static void init(MqttConfig clientConfig) {
 
-        MqttClientSingleton.brokerUrl = brokerUrl;
-        MqttClientSingleton.protocolVersion = protocolVersion;
-        MqttClientSingleton.clientId = clientId;
-        MqttClientSingleton.username = username;
-        MqttClientSingleton.password = password;
-        MqttClientSingleton.cleanSession = cleanSession;
-        MqttClientSingleton.keepAliveSeconds = keepAliveSeconds;
-        MqttClientSingleton.connectTimeoutSeconds = connectTimeoutSeconds;
-        MqttClientSingleton.tlsEnabled = tlsEnabled;
-        MqttClientSingleton.reconnectEnabled = reconnectEnabled;
-        MqttClientSingleton.initialDelayMs = initialDelayMs;
-        MqttClientSingleton.maxDelayMs = maxDelayMs;
-        MqttClientSingleton.sessionExpirySeconds = sessionExpirySeconds;
-        MqttClientSingleton.willTopic = willTopic;
-        MqttClientSingleton.willPayload = willPayload;
-        MqttClientSingleton.willQos = willQos;
-        MqttClientSingleton.willRetain = willRetain;
-        MqttClientSingleton.willDelaySeconds = willDelaySeconds;
-        MqttClientSingleton.willMessageExpirySeconds = willMessageExpirySeconds;
+        MqttClientSingleton.brokerUrl = clientConfig.getBrokerUrl();
+        MqttClientSingleton.protocolVersion = clientConfig.getProtocolVersion();
+        MqttClientSingleton.clientId = clientConfig.getClientId();
+        MqttClientSingleton.username = clientConfig.getUsername();
+        MqttClientSingleton.password = clientConfig.getPassword();
+        MqttClientSingleton.cleanSession = clientConfig.isCleanSession();
+        MqttClientSingleton.keepAliveSeconds = clientConfig.getKeepAliveSeconds();
+        MqttClientSingleton.connectTimeoutSeconds = clientConfig.getConnectTimeoutSeconds();
+        MqttClientSingleton.tlsEnabled = clientConfig.isTlsEnabled();
+        MqttClientSingleton.sessionExpirySeconds = clientConfig.getSessionExpirySeconds();
+        
+        MqttConfig.ReconnectConfig reconnectConfig = clientConfig.getReconnectConfig();
+        MqttClientSingleton.reconnectEnabled = reconnectConfig.isEnabled();
+        MqttClientSingleton.initialDelayMs = reconnectConfig.getInitialDelayMs();
+        MqttClientSingleton.maxDelayMs = reconnectConfig.getMaxDelayMs();
 
+        MqttConfig.WillConfig willConfig = clientConfig.getWillConfig();
+        MqttClientSingleton.willTopic = willConfig.getWillTopic();
+        MqttClientSingleton.willPayload = willConfig.getWillPayload();
+        MqttClientSingleton.willQos = willConfig.getWillQos();
+        MqttClientSingleton.willRetain = willConfig.getWillRetain();
+        MqttClientSingleton.willDelaySeconds = willConfig.getWillDelaySeconds();
+        MqttClientSingleton.willMessageExpirySeconds = willConfig.getWillMessageExpirySeconds();
 
         initialized = true;
     }
@@ -268,7 +234,13 @@ public class MqttClientSingleton {
 
             connectFuture.get(connectTimeoutSeconds, TimeUnit.SECONDS);
             
-        } catch (Exception e) {
+        } catch (InterruptedException ie) {
+            LOGGER.error(ansi().fg(RED).bold().a("Cannot connect to MQTT broker.").reset().toString() 
+                    + "Connection interrupted, The application may be shutting down.", ie);
+                    connected = false;
+                    Thread.currentThread().interrupt();
+        }
+        catch (Exception e) {
             LOGGER.error(ansi().fg(RED).bold().a("Cannot connect to MQTT broker.").reset().toString() 
                     + "Check that the broker is running and" 
                     + "the configuration property '/mqtt-client/broker-url'" 

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttClientSingleton.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttClientSingleton.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.hivemq.client.mqtt.MqttClient;
+import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3AsyncClient;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3ClientBuilder;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
@@ -50,6 +51,8 @@ import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientBuilder;
  * The singleton instance is initialized via the {@link #init} method and can be retrieved
  * using {@link #getInstance()} or {@link #get()}.
  * </p>
+ * 
+ * @author Harshit Sharma {@literal <harshitsharma635@gmail.com>}
  */
 public class MqttClientSingleton {
 
@@ -81,6 +84,18 @@ public class MqttClientSingleton {
     private static long initialDelayMs;
     /** The maximum delay in milliseconds for reconnection attempts. */
     private static long maxDelayMs;
+    /** The will message topic (optional). */
+    private static String willTopic;
+    /** The will message payload (optional). */
+    private static String willPayload;
+    /** The will message QoS level (0, 1, or 2). */
+    private static int willQos;
+    /** Whether the will message should be retained. */
+    private static boolean willRetain;
+    /** The will delay interval in seconds (MQTT v5 only). */
+    private static long willDelaySeconds;
+    /** The will message expiry interval in seconds (MQTT v5 only, optional). */
+    private static Long willMessageExpirySeconds;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MqttClientSingleton.class);
 
@@ -92,19 +107,25 @@ public class MqttClientSingleton {
     /**
      * Initializes the MQTT client singleton with the specified configuration parameters.
      *
-     * @param brokerUrl             the broker endpoint URL
-     * @param protocolVersion       the MQTT protocol version (3 or 5)
-     * @param clientId              the unique identifier for the client
-     * @param username              the username for authentication (can be null)
-     * @param password              the password for authentication (can be null)
-     * @param cleanSession          whether to clear session state on connection
-     * @param keepAliveSeconds      the keep-alive interval in seconds
-     * @param sessionExpirySeconds  the session expiry interval in seconds (MQTT v5 only)
-     * @param connectTimeoutSeconds the connection timeout in seconds
-     * @param tlsEnabled            whether TLS/SSL should be enabled
-     * @param reconnectEnabled      whether automatic reconnection should be enabled
-     * @param initialDelayMs        the initial delay in milliseconds for reconnection
-     * @param maxDelayMs            the maximum delay in milliseconds for reconnection
+     * @param brokerUrl                the broker endpoint URL
+     * @param protocolVersion          the MQTT protocol version (3 or 5)
+     * @param clientId                 the unique identifier for the client
+     * @param username                 the username for authentication (can be null)
+     * @param password                 the password for authentication (can be null)
+     * @param cleanSession             whether to clear session state on connection
+     * @param keepAliveSeconds         the keep-alive interval in seconds
+     * @param sessionExpirySeconds     the session expiry interval in seconds (MQTT v5 only)
+     * @param connectTimeoutSeconds    the connection timeout in seconds
+     * @param tlsEnabled               whether TLS/SSL should be enabled
+     * @param reconnectEnabled         whether automatic reconnection should be enabled
+     * @param initialDelayMs           the initial delay in milliseconds for reconnection
+     * @param maxDelayMs               the maximum delay in milliseconds for reconnection
+     * @param willTopic                the will message topic (can be null)
+     * @param willPayload              the will message payload (can be null)
+     * @param willQos                  the will message QoS level (0,1, or 2)
+     * @param willRetain               whether the will message should be retained
+     * @param willDelaySeconds         the will delay interval in seconds (MQTT v5 only)
+     * @param willMessageExpirySeconds the will message expiry interval in seconds (MQTT v5 only)
      */
     public static void init(
             String brokerUrl,
@@ -119,7 +140,13 @@ public class MqttClientSingleton {
             boolean tlsEnabled,
             boolean reconnectEnabled,
             long initialDelayMs,
-            long maxDelayMs) {
+            long maxDelayMs,
+            String willTopic,
+            String willPayload,
+            int willQos,
+            boolean willRetain,
+            long willDelaySeconds,
+            Long willMessageExpirySeconds) {
 
         MqttClientSingleton.brokerUrl = brokerUrl;
         MqttClientSingleton.protocolVersion = protocolVersion;
@@ -134,6 +161,13 @@ public class MqttClientSingleton {
         MqttClientSingleton.initialDelayMs = initialDelayMs;
         MqttClientSingleton.maxDelayMs = maxDelayMs;
         MqttClientSingleton.sessionExpirySeconds = sessionExpirySeconds;
+        MqttClientSingleton.willTopic = willTopic;
+        MqttClientSingleton.willPayload = willPayload;
+        MqttClientSingleton.willQos = willQos;
+        MqttClientSingleton.willRetain = willRetain;
+        MqttClientSingleton.willDelaySeconds = willDelaySeconds;
+        MqttClientSingleton.willMessageExpirySeconds = willMessageExpirySeconds;
+
 
         initialized = true;
     }
@@ -266,6 +300,23 @@ public class MqttClientSingleton {
                 .applySimpleAuth();
         }
 
+        // Configure will message if provided
+        if (willTopic != null && willPayload != null) {
+            var willPublishBuilder = builder.willPublish()
+                .topic(willTopic)
+                .payload(willPayload.getBytes(StandardCharsets.UTF_8))
+                .qos(MqttQos.fromCode(willQos))
+                .retain(willRetain)
+                .delayInterval(willDelaySeconds);
+
+            // Add message expiry if provided
+            if (willMessageExpirySeconds != null) {
+                willPublishBuilder.messageExpiryInterval(willMessageExpirySeconds);
+            }
+
+            willPublishBuilder.applyWillPublish();
+        }
+
         // Configure automatic reconnect
         if (reconnectEnabled) {
             builder.automaticReconnect()
@@ -301,6 +352,16 @@ public class MqttClientSingleton {
                 .username(username)
                 .password(password.getBytes())
                 .applySimpleAuth();
+        }
+
+        // Configure will message if provided
+        if (willTopic != null && willPayload != null) {
+            builder.willPublish()
+                .topic(willTopic)
+                .payload(willPayload.getBytes(StandardCharsets.UTF_8))
+                .qos(MqttQos.fromCode(willQos))
+                .retain(willRetain)
+                .applyWillPublish();
         }
 
         // Configure automatic reconnect

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttClientSingleton.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttClientSingleton.java
@@ -1,0 +1,367 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-mongoclient-provider
+ * %%
+ * Copyright (C) 2014 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+package org.restheart.mqtt;
+
+import static org.fusesource.jansi.Ansi.ansi;
+import static org.fusesource.jansi.Ansi.Color.GREEN;
+import static org.fusesource.jansi.Ansi.Color.RED;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.restheart.utils.BootstrapLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.hivemq.client.mqtt.MqttClient;
+import com.hivemq.client.mqtt.mqtt3.Mqtt3AsyncClient;
+import com.hivemq.client.mqtt.mqtt3.Mqtt3ClientBuilder;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientBuilder;
+
+/**
+ * Thread-safe singleton that manages the lifecycle of a MQTT clien=t  {@link MqttClient}.
+ * <p>
+ * This singleton can be configured to use either MQTT v3 or MQTT v5 protocols.
+ * It provides features such as automatic reconnection, authentication (username/password),
+ * TLS/SSL support, keep-alive, and session management.
+ * </p>
+ * <p>
+ * The singleton instance is initialized via the {@link #init} method and can be retrieved
+ * using {@link #getInstance()} or {@link #get()}.
+ * </p>
+ */
+public class MqttClientSingleton {
+
+    /** Indicates whether the singleton has been initialized with configuration parameters. */
+    private static boolean initialized = false;
+    /** The MQTT broker URL (e.g., "tcp://localhost:1883"). */
+    private static String brokerUrl;
+    /** The MQTT protocol version (3 or 5). */
+    private static int protocolVersion;
+    /** The unique client identifier for connection to the broker. */
+    private static String clientId;
+    /** The username for broker authentication (optional). */
+    private static String username;
+    /** The password for broker authentication (optional). */
+    private static String password;
+    /** Whether to start clean sessions or resume previous ones. */
+    private static boolean cleanSession;
+    /** The keep-alive interval in seconds. */
+    private static int keepAliveSeconds;
+    /** The session expiry interval in seconds (MQTT v5 only). */
+    private static long sessionExpirySeconds;
+    /** The connection timeout in seconds. */
+    private static int connectTimeoutSeconds;
+    /** Whether SSL/TLS is enabled for connections. */
+    private static boolean tlsEnabled;
+    /** Whether automatic reconnection is enabled. */
+    private static boolean reconnectEnabled;
+    /** The initial delay in milliseconds for reconnection attempts. */
+    private static long initialDelayMs;
+    /** The maximum delay in milliseconds for reconnection attempts. */
+    private static long maxDelayMs;
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MqttClientSingleton.class);
+
+    /** The underlying HiveMQ MQTT client instance. */
+    private MqttClient mqttClient; // Either Mqtt3AsyncClient or Mqtt5AsyncClient
+    /** Flag indicating whether the client is currently connected. */
+    private boolean connected = false;
+
+    /**
+     * Initializes the MQTT client singleton with the specified configuration parameters.
+     *
+     * @param brokerUrl             the broker endpoint URL
+     * @param protocolVersion       the MQTT protocol version (3 or 5)
+     * @param clientId              the unique identifier for the client
+     * @param username              the username for authentication (can be null)
+     * @param password              the password for authentication (can be null)
+     * @param cleanSession          whether to clear session state on connection
+     * @param keepAliveSeconds      the keep-alive interval in seconds
+     * @param sessionExpirySeconds  the session expiry interval in seconds (MQTT v5 only)
+     * @param connectTimeoutSeconds the connection timeout in seconds
+     * @param tlsEnabled            whether TLS/SSL should be enabled
+     * @param reconnectEnabled      whether automatic reconnection should be enabled
+     * @param initialDelayMs        the initial delay in milliseconds for reconnection
+     * @param maxDelayMs            the maximum delay in milliseconds for reconnection
+     */
+    public static void init(
+            String brokerUrl,
+            int protocolVersion,
+            String clientId,
+            String username,
+            String password,
+            boolean cleanSession,
+            int keepAliveSeconds,
+            long sessionExpirySeconds,
+            int connectTimeoutSeconds,
+            boolean tlsEnabled,
+            boolean reconnectEnabled,
+            long initialDelayMs,
+            long maxDelayMs) {
+
+        MqttClientSingleton.brokerUrl = brokerUrl;
+        MqttClientSingleton.protocolVersion = protocolVersion;
+        MqttClientSingleton.clientId = clientId;
+        MqttClientSingleton.username = username;
+        MqttClientSingleton.password = password;
+        MqttClientSingleton.cleanSession = cleanSession;
+        MqttClientSingleton.keepAliveSeconds = keepAliveSeconds;
+        MqttClientSingleton.connectTimeoutSeconds = connectTimeoutSeconds;
+        MqttClientSingleton.tlsEnabled = tlsEnabled;
+        MqttClientSingleton.reconnectEnabled = reconnectEnabled;
+        MqttClientSingleton.initialDelayMs = initialDelayMs;
+        MqttClientSingleton.maxDelayMs = maxDelayMs;
+        MqttClientSingleton.sessionExpirySeconds = sessionExpirySeconds;
+
+        initialized = true;
+    }
+
+    /**
+     * Checks if the singleton has been initialized.
+     *
+     * @return {@code true} if initialized, {@code false} otherwise
+     */
+    public static boolean isInitialized() {
+        return initialized;
+    }
+
+    /**
+     * Alias for {@link #getInstance()} to retrieve the singleton instance.
+     *
+     * @return the singleton {@link MqttClientSingleton} instance
+     */
+    public static MqttClientSingleton get() {
+        return getInstance();
+    }
+
+    /**
+     * Retrieves the singleton {@link MqttClientSingleton} instance.
+     *
+     * @return the singleton {@link MqttClientSingleton} instance
+     */
+    public static MqttClientSingleton getInstance() {
+        return MqttClientSingletonHolder.INSTANCE;
+    }
+
+    /**
+     * Private constructor to enforce singleton pattern.
+     * Throws an exception if the singleton is not initialized yet.
+     *
+     * @throws IllegalStateException if called before initialization
+     */
+    private MqttClientSingleton() {
+        if (!initialized) {
+            throw new IllegalStateException("MqttClientSingleton is not initialized");
+        }
+    }
+
+    /**
+     * Establishes a connection to the MQTT broker asynchronously, waiting for the connection
+     * to be established up to the configured connection timeout limit.
+     *
+     * @throws IllegalStateException if the singleton is not initialized
+     */
+    public void connect() {
+        if (!initialized) {
+            throw new IllegalStateException("MqttClientSingleton is not initialized");
+        }
+
+        if (mqttClient != null && connected) {
+            LOGGER.debug("MQTT Client already connected");
+            return;
+        }
+
+        BootstrapLogger.standalone(LOGGER, "Connecting to MQTT broker at {}...", brokerUrl);
+
+        try {
+            //Parse broker URL
+            URI uri = new URI(brokerUrl);
+            String host = uri.getHost();
+            int port = uri.getPort() > 0 ? uri.getPort() : (tlsEnabled ? 8883 : 1883);
+
+            // Build client based on protocol version
+            if (protocolVersion == 5) {
+                mqttClient = buildMqtt5Client(host, port);
+            } else {
+                mqttClient = buildMqtt3Client(host, port);
+            }
+
+            // Attempt connection
+            CompletableFuture<Void> connectFuture;
+            if (mqttClient instanceof Mqtt5AsyncClient) {
+                connectFuture = ((Mqtt5AsyncClient) mqttClient).connectWith()
+                    .keepAlive(keepAliveSeconds)
+                    .cleanStart(cleanSession)
+                    .sessionExpiryInterval(sessionExpirySeconds)
+                    .send()
+                    .thenAccept(connAck -> {
+                    connected = true;
+                    BootstrapLogger.standalone(LOGGER, "Connected to MQTT broker {} (MQTT 5.0)", 
+                        ansi().fg(GREEN).bold().a(brokerUrl).reset().toString());
+                });
+            } else {
+                connectFuture = ((Mqtt3AsyncClient) mqttClient).connectWith()
+                    .cleanSession(cleanSession)
+                    .keepAlive(keepAliveSeconds)
+                    .send()
+                    .thenAccept(connAck -> {
+                    connected = true;
+                    BootstrapLogger.standalone(LOGGER, "Connected to MQTT broker {} (MQTT 5.0)", ansi().fg(GREEN).bold().a(brokerUrl).reset().toString());
+                });
+            }
+
+            connectFuture.get(connectTimeoutSeconds, TimeUnit.SECONDS);
+            
+        } catch (Exception e) {
+            LOGGER.error(ansi().fg(RED).bold().a("Cannot connect to MQTT broker.").reset().toString() 
+                    + "Check that the broker is running and" 
+                    + "the configuration property '/mqtt-client/broker-url'" 
+                    + "is set properly", e);
+            connected = false;
+        }
+
+    }
+
+    /**
+     * Builds and configures an asynchronous MQTT 5.0 client.
+     *
+     * @param host the broker host address
+     * @param port the broker port
+     * @return the constructed {@link Mqtt5AsyncClient}
+     */
+    private Mqtt5AsyncClient buildMqtt5Client(String host, int port) {
+        Mqtt5ClientBuilder builder = MqttClient.builder()
+            .useMqttVersion5()
+            .identifier(clientId)
+            .serverHost(host)
+            .serverPort(port);
+        
+        //Add authentication if provided
+        if (username != null && password != null) {
+            builder.simpleAuth()
+                .username(username)
+                .password(password.getBytes(StandardCharsets.UTF_8))
+                .applySimpleAuth();
+        }
+
+        // Configure automatic reconnect
+        if (reconnectEnabled) {
+            builder.automaticReconnect()
+                .initialDelay(initialDelayMs, TimeUnit.MILLISECONDS)
+                .maxDelay(maxDelayMs, TimeUnit.MILLISECONDS)
+                .applyAutomaticReconnect();
+        }
+
+        if (tlsEnabled) {
+            builder.sslWithDefaultConfig();
+        }
+
+        return builder.buildAsync();
+    }
+
+    /**
+     * Builds and configures an asynchronous MQTT 3.0 client.
+     *
+     * @param host the broker host address
+     * @param port the broker port
+     * @return the constructed {@link Mqtt3AsyncClient}
+     */
+    private Mqtt3AsyncClient buildMqtt3Client(String host, int port) {
+        Mqtt3ClientBuilder builder = MqttClient.builder()
+            .useMqttVersion3()
+            .identifier(clientId)
+            .serverHost(host)
+            .serverPort(port);
+        
+        // Add authentication if provided
+        if (username != null && password != null) {
+            builder.simpleAuth()
+                .username(username)
+                .password(password.getBytes())
+                .applySimpleAuth();
+        }
+
+        // Configure automatic reconnect
+        if (reconnectEnabled) {
+            builder.automaticReconnect()
+                .initialDelay(initialDelayMs, TimeUnit.MILLISECONDS)
+                .maxDelay(maxDelayMs, TimeUnit.MILLISECONDS)
+                .applyAutomaticReconnect();
+        }
+
+        // Configure TLS if enabled
+        if (tlsEnabled) {
+            builder.sslWithDefaultConfig();
+        }
+
+        return builder.buildAsync();
+    }
+
+    /**
+     * Returns the underlying {@link MqttClient} instance.
+     * If the client is not yet created or connected, this method will trigger the connection.
+     *
+     * @return the underlying {@link MqttClient} instance
+     * @throws IllegalStateException if the singleton is not initialized
+     */
+    public MqttClient getClient() {
+        if (!initialized) {
+            throw new IllegalStateException("MqttClientSingleton is not initialized");
+        }
+
+        if (mqttClient == null) {
+            connect();
+        }
+
+        return mqttClient;
+    }
+
+    /**
+     * Initialization-on-demand holder idiom to hold the singleton instance.
+     * <p>
+     * To ensure singleton integrity across classloaders (e.g., in plugin environments),
+     * the instance is registered in the system properties.
+     * </p>
+     */
+    private static class MqttClientSingletonHolder {
+        private static final MqttClientSingleton INSTANCE;
+
+        // Make sure the Singleton is a Singleton even in a multi
+        static {
+            synchronized (ClassLoader.getSystemClassLoader()) {
+                final var sysProps = System.getProperties();
+                final var singleton = (MqttClientSingleton) sysProps.get(MqttClientSingleton.class.getName());
+
+                if (singleton != null) {
+                    INSTANCE = singleton;
+                } else {
+                    INSTANCE = new MqttClientSingleton();
+                    System.getProperties().put(MqttClientSingleton.class.getName(), INSTANCE);
+                }
+            }
+        }
+    }
+    
+}

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttConfig.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttConfig.java
@@ -1,0 +1,268 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-mongoclient-provider
+ * %%
+ * Copyright (C) 2014 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+
+package org.restheart.mqtt;
+
+/**
+ * Configuration class for MQTT client settings.
+ * <p>
+ * This class encapsulates all configuration parameters needed to initialize
+ * an MQTT client connection. It uses the Builder pattern to provide a fluent
+ * API for constructing configuration instances.
+ * </p>
+ *
+ * @author Harshit Sharma {@literal <harshitsharma635@gmail.com>}
+ */
+public class MqttConfig {
+    
+    private String brokerUrl;
+    private int protocolVersion;
+    private String clientId;
+    private String username;
+    private String password;
+    private boolean cleanSession;
+    private int keepAliveSeconds;
+    private long sessionExpirySeconds;
+    private int connectTimeoutSeconds;
+    private boolean tlsEnabled;
+    private ReconnectConfig reconnectConfig;
+    private WillConfig willConfig;
+   
+
+    private MqttConfig(Builder builder) {
+        this.brokerUrl = builder.brokerUrl;
+        this.protocolVersion = builder.protocolVersion;
+        this.clientId = builder.clientId;
+        this.username = builder.username;
+        this.password = builder.password;
+        this.cleanSession = builder.cleanSession;
+        this.keepAliveSeconds = builder.keepAliveSeconds;
+        this.sessionExpirySeconds = builder.sessionExpirySeconds;
+        this.connectTimeoutSeconds = builder.connectTimeoutSeconds;
+        this.tlsEnabled = builder.tlsEnabled;
+        this.reconnectConfig = builder.reconnectConfig;
+        this.willConfig = builder.willConfig;
+    }
+
+    public String getBrokerUrl() {
+        return brokerUrl;
+    }
+
+    public int getProtocolVersion() {
+        return protocolVersion;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public boolean isCleanSession() {
+        return cleanSession;
+    }
+
+    public int getKeepAliveSeconds() {
+        return keepAliveSeconds;
+    }
+
+    public long getSessionExpirySeconds() {
+        return sessionExpirySeconds;
+    }
+
+    public int getConnectTimeoutSeconds() {
+        return connectTimeoutSeconds;
+    }
+
+    public boolean isTlsEnabled() {
+        return tlsEnabled;
+    }
+
+    public ReconnectConfig getReconnectConfig() {
+        return reconnectConfig;
+    }
+
+    public WillConfig getWillConfig() {
+        return willConfig;
+    }
+
+    /**
+     * Configuration for automatic reconnection behavior.
+     */
+    public static class ReconnectConfig {
+        private boolean enabled;
+        private long initialDelayMs;
+        private long maxDelayMs;
+
+        public ReconnectConfig(boolean enabled, long initialDelayMs, long maxDelayMs) {
+            this.enabled = enabled;
+            this.initialDelayMs = initialDelayMs;
+            this.maxDelayMs = maxDelayMs;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public long getInitialDelayMs() {
+            return initialDelayMs;
+        }
+
+        public long getMaxDelayMs() {
+            return maxDelayMs;
+        }
+    }
+
+    /**
+     * Configuration for MQTT Last will message.
+     */
+    public static class WillConfig {
+        private  String willTopic;
+        private  String willPayload;
+        private  int willQos;
+        private  boolean willRetain;
+        private  long willDelaySeconds;
+        private  Long willMessageExpirySeconds;
+
+        public WillConfig(String topic, String payload, int Qos, boolean retain, 
+            long delaySeconds, Long messageExpirySeconds) {
+            
+            this.willTopic = topic;
+            this.willPayload = payload;
+            this.willQos = Qos;
+            this.willRetain = retain;
+            this.willDelaySeconds = delaySeconds;
+            this.willMessageExpirySeconds = messageExpirySeconds;
+        }
+
+        public String getWillTopic() {
+            return willTopic;
+        }
+
+        public String getWillPayload() {
+            return willPayload;
+        }
+
+        public int getWillQos() {
+            return willQos;
+        }
+
+        public boolean getWillRetain() {
+            return willRetain;
+        }
+
+        public long getWillDelaySeconds() {
+            return willDelaySeconds;
+        }
+
+        public Long getWillMessageExpirySeconds() {
+            return willMessageExpirySeconds;
+        }
+    }
+
+    /**
+     * Builder for creating MqttConfig instances.
+     */
+    public static class Builder {
+        private  String brokerUrl;
+        private  int protocolVersion;
+        private  String clientId;
+        private  String username;
+        private  String password;
+        private  boolean cleanSession;
+        private  int keepAliveSeconds;
+        private  long sessionExpirySeconds;
+        private  int connectTimeoutSeconds;
+        private  boolean tlsEnabled;
+        private  ReconnectConfig reconnectConfig;
+        private WillConfig willConfig;
+
+        public Builder brokerUrl(String brokerUrl) {
+            this.brokerUrl = brokerUrl;
+            return this;
+        }
+
+        public Builder protocolVersion(int protocolVersion) {
+            this.protocolVersion = protocolVersion;
+            return this;
+        }
+
+        public Builder clientId(String clientId) {
+            this.clientId = clientId;
+            return this;
+        }
+
+        public Builder username(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public Builder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public Builder cleanSession(boolean cleanSession) {
+            this.cleanSession = cleanSession;
+            return this;
+        }
+
+        public Builder keepAliveSeconds(int keepAliveSeconds) {
+            this.keepAliveSeconds = keepAliveSeconds;
+            return this;
+        }
+
+        public Builder sessionExpirySeconds(long sessionExpirySeconds) {
+            this.sessionExpirySeconds = sessionExpirySeconds;
+            return this;
+        }
+
+        public Builder connectTimeoutSeconds(int connectTimeoutSeconds) {
+            this.connectTimeoutSeconds = connectTimeoutSeconds;
+            return this;
+        }
+
+        public Builder tlsEnabled(boolean tlsEnabled) {
+            this.tlsEnabled = tlsEnabled;
+            return this;
+        }
+
+        public Builder reconnectConfig(ReconnectConfig reconnectConfig) {
+            this.reconnectConfig = reconnectConfig;
+            return this;
+        }
+
+        public Builder willConfig(WillConfig willConfig) {
+            this.willConfig = willConfig;
+            return this;
+        }
+
+        public MqttConfig build() {
+            return new MqttConfig(this);
+        }
+    }
+}

--- a/mqtt/src/main/resources/restheart-mqtt-default-config.yml
+++ b/mqtt/src/main/resources/restheart-mqtt-default-config.yml
@@ -1,0 +1,70 @@
+plugins-args:
+  mqtt-client:
+    enabled: true
+    broker-url: "tcp://localhost:1883"          # or ssl://, ws://, wss://
+    protocol-version: 3                         # 3 = MQTT 3.1.1 (default), 5 = MQTT 5.0
+    client-id: "restheart"                      # auto-suffixed with UUID if blank
+    username: ~
+    password: ~
+    clean-session: false
+    keep-alive-seconds: 60
+    session-expiry-seconds: 0xFFFFFFFF          # MQTT 5 only (max = never expires)
+    connect-timeout-seconds: 10
+    tls: false
+    tls-trust-store: ~                          # path to JKS/PKCS12
+    tls-trust-store-password: ~
+    max-inflight-messages-per-second: 5000      # global router rate limit (0 = unlimited)
+    reconnect:
+      enabled: true
+      initial-delay-ms: 1000                    # exponential backoff: 1s, 2s, 4s, 8s, 16...
+      max-delay-ms: 30000                       # max delay cap (HiveMQ client uses fixed 2.0 multiplier)
+    subscriptions:
+      - topic: "sensors/#"
+        qos: 1
+      - topic: "traffic/#"
+        qos: 0
+
+  #MQTT SSE Service - Stream MQTT messages as Server-sent Events
+  mqtt-sse:
+    enabled: true
+    default-topic: "sensors/#"
+    default-qos: 1
+    max-connections-per-topic: 100
+    per-connection-queue-capacity: 256          # per-client bounded queue; overflow = drop
+    last-message-cache: true
+    payload-envelope: false                     # true = wrap in {topic, payload, receivedAt, qos}
+    pipeline:                                   # optional per-topic pipeline overrides
+      - topic: "sensors/#"
+        stages:
+          - type: throttle
+            max-events-per-second: 10
+          - type: tumbling-window
+            window-ms: 1000
+            function: avg                       # avg | min | max | count | last
+            field: "$.value"                    # JSONPath to numeric field to aggregate
+
+  # MQTT REST Service - Poll last message per topic
+  mqtt-rest:
+    enabled: true
+
+  # MQTT MongoDB Writer - Persist MQTT messages to MongoDB
+  mqtt-mongo-writer:
+    enabled: false
+    buffer:
+      strategy: "ring-buffer"                   # "ring-buffer" | "blocking-queue"
+      capacity: 10000
+      overflow-action: "drop-oldest"            # "drop-oldest" | "drop-incoming" | "block"
+    drain:
+      batch-size: 200
+      flush-interval-ms: 500
+      max-retries: 3
+      retry-delay-ms: 1000
+    id-strategy: "auto"                         # "auto" | "payload-field" | "topic-timestamp-hash"
+    id-field: "messageId"                       # field name when id-strategy = "payload-field"
+    mongo-sink:
+      - topic: "sensors/#"
+        database: "iot"
+        collection: "sensor-events"
+      - topic: "traffic/#"
+        database: "iot"
+        collection: "traffic-events"

--- a/mqtt/src/main/resources/restheart-mqtt-default-config.yml
+++ b/mqtt/src/main/resources/restheart-mqtt-default-config.yml
@@ -14,6 +14,13 @@ plugins-args:
     tls-trust-store: ~                          # path to JKS/PKCS12
     tls-trust-store-password: ~
     max-inflight-messages-per-second: 5000      # global router rate limit (0 = unlimited)
+    will:
+      topic: ~
+      payload: ~
+      qos: 0
+      retain: false
+      delay-seconds: 0
+      message-expiry-seconds: ~
     reconnect:
       enabled: true
       initial-delay-ms: 1000                    # exponential backoff: 1s, 2s, 4s, 8s, 16...

--- a/mqtt/src/test/java/org/restheart/mqtt/MqttClientProviderTest.java
+++ b/mqtt/src/test/java/org/restheart/mqtt/MqttClientProviderTest.java
@@ -1,0 +1,328 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-mongoclient-provider
+ * %%
+ * Copyright (C) 2014 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+
+package org.restheart.mqtt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Unit tests for MqttClientProvider configuration parsing and initialization
+ * Tests verify that the provider correctly parses configuration and initializes
+ * MqttClientSingleton with the expected values.
+ * 
+ * @author Harshit Sharma {@literal <harshitsharma635@gmail.com>}
+ */
+public class MqttClientProviderTest {
+    
+    private MqttClientProvider provider;
+    private Map<String, Object> config;
+
+    @BeforeEach
+    public void setUp() {
+        provider = new MqttClientProvider();
+        // provider.init();
+        config = new HashMap<>();
+        //Reset MqttClientSingleton state between tests
+        resetMqttClientSingleton();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        // Clean up singleton state after each test
+        resetMqttClientSingleton();
+    }
+
+    /**
+     * Resets the MqttClientSingleton state using reflection
+     */
+    private void resetMqttClientSingleton() {
+        try {
+            Field initializedField = MqttClientSingleton.class.getDeclaredField("initialized");
+            initializedField.setAccessible(true);
+            initializedField.setBoolean(null, false);
+        } catch (Exception e) {
+            // Ignore if field doesn't exist or can't be accessed
+        }
+    }
+    /**
+     * Injects the config map into the provider using reflection.
+     * @throws Exception
+     */
+    private void injectConfig() throws Exception {
+        Field configField = MqttClientProvider.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        configField.set(provider, config);
+    }
+
+    /**
+     * Gets a static field value from MqttClientSingleton using reflection
+     * @param fieldName
+     * @return
+     * @throws Exception
+     */
+    private Object getSingletonField(String fieldName) throws Exception {
+        Field field = MqttClientSingleton.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(null);
+    }
+
+    /**
+     * Calls init() without triggering actual MQTT connection by mocking getInstance()
+     * @throws Exception
+     */
+    private void callInitWithoutConnection() throws Exception {
+        injectConfig();
+
+        // Mock the singleton instance to prevent actual connection
+        MqttClientSingleton mockSingleton = mock(MqttClientSingleton.class);
+
+        // Mock the static getInstance method to return the mocked object
+        try (var mockedStatic = mockStatic(MqttClientSingleton.class, Mockito.CALLS_REAL_METHODS)) {
+            mockedStatic.when(MqttClientSingleton::getInstance).thenReturn(mockSingleton);
+
+            // System.out.println("MqttClientSingleton.getInstance(): " + MqttClientSingleton.getInstance());
+            // System.out.println("mockSingleton : " + mockSingleton);
+
+            // assertSame(mockSingleton, MqttClientSingleton.getInstance());
+            provider.init();
+
+            verify(mockSingleton).connect();
+        }
+    }
+
+    @Test
+    @DisplayName("Test default configuration values")
+    public void testDefaultConfiguration() throws Exception {
+        // Empty config should use all defaults
+        callInitWithoutConnection();
+
+        // Verify defaults were set in singleton
+        assertTrue(MqttClientSingleton.isInitialized());
+        assertEquals("tcp://localhost:1883", getSingletonField("brokerUrl"));
+        assertEquals(3, getSingletonField("protocolVersion"));
+        assertTrue(((String) getSingletonField("clientId")).startsWith("restheart-"));
+        assertNull(getSingletonField("username"));
+        assertNull(getSingletonField("password"));
+        assertEquals(false, getSingletonField("cleanSession"));
+        assertEquals(60, getSingletonField("keepAliveSeconds"));
+        assertEquals(0xFFFFFFFFL, getSingletonField("sessionExpirySeconds"));
+        assertEquals(10, getSingletonField("connectTimeoutSeconds"));
+        assertEquals(false, getSingletonField("tlsEnabled"));
+        assertEquals(true, getSingletonField("reconnectEnabled"));
+        assertEquals(1000L, getSingletonField("initialDelayMs"));
+        assertEquals(30000L, getSingletonField("maxDelayMs"));
+        assertNull(getSingletonField("willTopic"));
+        assertNull(getSingletonField("willPayload"));
+        assertEquals(0, getSingletonField("willQos"));
+        assertEquals(false, getSingletonField("willRetain"));
+        assertEquals(0L, getSingletonField("willDelaySeconds"));
+        assertNull(getSingletonField("willMessageExpirySeconds"));
+    }
+
+    @Test
+    @DisplayName("Test custom broker URL configuration")
+    public void testCustomBrokerUrl() throws Exception {
+        config.put("broker-url", "ssl://mqtt.example.com:8883");
+        callInitWithoutConnection();
+
+        assertEquals("ssl://mqtt.example.com:8883", getSingletonField("brokerUrl"));
+    }
+
+    @Test
+    @DisplayName("Test MQTT 5 protocol version is parsed correctly")
+    public void testMqtt5ProtocolVersion() throws Exception {
+        config.put("protocol-version", 5);
+        callInitWithoutConnection();
+
+        assertEquals(5, getSingletonField("protocolVersion"));
+    }
+
+    @Test
+    @DisplayName("Test authentication credentials are parsed correctly")
+    public void testAuthenticationConfiguration()throws Exception {
+        config.put("username", "testuser");
+        config.put("password", "testpass");
+        callInitWithoutConnection();
+
+        assertEquals("testuser", getSingletonField("username"));
+        assertEquals("testpass", getSingletonField("password"));
+    }
+
+    @Test
+    @DisplayName("Test session configuration is parsed correctly")
+    public void testSessionConfiguration() throws Exception {
+        config.put("clean-session", true);
+        config.put("keep-alive-seconds", 120);
+        config.put("session-expiry-seconds", 3600L);
+        callInitWithoutConnection();
+
+        assertEquals(true, getSingletonField("cleanSession"));
+        assertEquals(120, getSingletonField("keepAliveSeconds"));
+        assertEquals(3600L, getSingletonField("sessionExpirySeconds"));
+    }
+
+    @Test
+    @DisplayName("Test TLS configuration is parsed correctly")
+    public void testTlsConfiguration() throws Exception {
+        config.put("tls", true);
+        callInitWithoutConnection();
+
+        assertEquals(true, getSingletonField("tlsEnabled"));
+    }
+
+    @Test
+    @DisplayName("Test reconnect configuration with nested map is parsed correctly")
+    public void testReconnectConfiguration() throws Exception {
+        Map<String, Object> reconnect = new HashMap<>();
+        reconnect.put("enabled", false);
+        reconnect.put("initial-delay-ms", 2000);
+        reconnect.put("max-delay-ms", 60000);
+        config.put("reconnect", reconnect);
+        callInitWithoutConnection();
+
+        assertEquals(false, getSingletonField("reconnectEnabled"));
+        assertEquals(2000L, getSingletonField("initialDelayMs"));
+        assertEquals(60000L, getSingletonField("maxDelayMs"));
+    }
+
+    @Test
+    @DisplayName("Test will message configuration for MQTT 3 is parsed correctly")
+    public void testWillMessageConfigurationMqtt3() throws Exception {
+        Map<String, Object> will = new HashMap<>();
+        will.put("topic", "device/status");
+        will.put("payload", "offline");
+        will.put("qos", 1);
+        will.put("retain", true);
+        config.put("will", will);
+        // config.put("protocol-version", 3);
+        callInitWithoutConnection();
+
+        assertEquals("device/status", getSingletonField("willTopic"));
+        assertEquals("offline", getSingletonField("willPayload"));
+        assertEquals(1, getSingletonField("willQos"));
+        assertEquals(true, getSingletonField("willRetain"));
+        assertEquals(0L, getSingletonField("willDelaySeconds")); // Default
+        assertNull(getSingletonField("willMessageExpirySeconds")); // Default
+    }
+
+    @Test
+    @DisplayName("Test will message configuration for MQTT 5 with delay and expiry is parsed correctly")
+    public void testWillMessageConfigurationMqtt5() throws Exception {
+        Map<String, Object> will = new HashMap<>();
+        will.put("topic", "device/status");
+        will.put("payload", "offline");
+        will.put("qos", 2);
+        will.put("retain", false);
+        will.put("delay-seconds", 30);
+        will.put("message-expiry-seconds", 3600);
+        config.put("will", will);
+        // config.put("protocol-version", 5);
+        callInitWithoutConnection();
+
+        assertEquals("device/status", getSingletonField("willTopic"));
+        assertEquals("offline", getSingletonField("willPayload"));
+        assertEquals(2, getSingletonField("willQos"));
+        assertEquals(false, getSingletonField("willRetain"));
+        assertEquals(30L, getSingletonField("willDelaySeconds"));
+        assertEquals(3600, getSingletonField("willMessageExpirySeconds"));
+    }
+
+    @Test
+    @DisplayName("Test will message with null topic and payload defaults correctly")
+    public void testWillMessageWithNullValues() throws Exception {
+        Map<String, Object> will = new HashMap<>();
+        will.put("topic", null);
+        will.put("payload", null);
+        config.put("will", will);
+        callInitWithoutConnection();
+
+        assertNull(getSingletonField("willTopic"));
+        assertNull(getSingletonField("willPayload"));
+        assertEquals(0, getSingletonField("willQos")); // Default
+        assertEquals(false, getSingletonField("willRetain")); // Default
+    }
+
+    @Test
+    @DisplayName("Test will message expiry as null (no expiry) is handled correctly")
+    public void testWillMessageExpiryNull() throws Exception {
+        Map<String, Object> will = new HashMap<>();
+        will.put("topic", "test/topic");
+        will.put("payload", "test");
+        will.put("message-expiry-seconds", null);
+        config.put("will", will);
+        callInitWithoutConnection();
+
+        assertNull(getSingletonField("willMessageExpirySeconds"));
+    }
+
+    @Test
+    @DisplayName("Test configuration with only required fields uses defaults for optional fields")
+    public void testConfigurationWithMissingOptionalFields() throws Exception {
+        // Only set broker URL
+        config.put("broker-url", "tcp://localhost:1883");
+        callInitWithoutConnection();
+
+        // Verify required field is set
+        assertEquals("tcp://localhost:1883", getSingletonField("brokerUrl"));
+
+        // Verify optional fields use defaults
+        assertNull(getSingletonField("username"));
+        assertNull(getSingletonField("password"));
+        assertNull(getSingletonField("willTopic"));
+        assertNull(getSingletonField("willPayload"));
+        assertEquals(true, getSingletonField("reconnectEnabled")); // Default
+    }
+
+    @Test
+    @DisplayName("Test custom client ID is parsed correctly")
+    public void testCustomClientId() throws Exception {
+        config.put("client-id", "my-custom-client");
+        callInitWithoutConnection();
+
+        assertEquals("my-custom-client", getSingletonField("clientId"));
+    }
+
+    @Test
+    @DisplayName("Test connect timeout is parsed correctly")
+    public void testConnectTimeout() throws Exception {
+        config.put("connect-timeout-seconds", 30);
+        callInitWithoutConnection();
+
+        assertEquals(30, getSingletonField("connectTimeoutSeconds"));
+    }
+}

--- a/mqtt/src/test/java/org/restheart/mqtt/MqttClientProviderTest.java
+++ b/mqtt/src/test/java/org/restheart/mqtt/MqttClientProviderTest.java
@@ -23,12 +23,9 @@ package org.restheart.mqtt;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Field;
 import java.util.HashMap;
@@ -55,7 +52,6 @@ public class MqttClientProviderTest {
     @BeforeEach
     public void setUp() {
         provider = new MqttClientProvider();
-        // provider.init();
         config = new HashMap<>();
         //Reset MqttClientSingleton state between tests
         resetMqttClientSingleton();
@@ -115,13 +111,7 @@ public class MqttClientProviderTest {
         try (var mockedStatic = mockStatic(MqttClientSingleton.class, Mockito.CALLS_REAL_METHODS)) {
             mockedStatic.when(MqttClientSingleton::getInstance).thenReturn(mockSingleton);
 
-            // System.out.println("MqttClientSingleton.getInstance(): " + MqttClientSingleton.getInstance());
-            // System.out.println("mockSingleton : " + mockSingleton);
-
-            // assertSame(mockSingleton, MqttClientSingleton.getInstance());
             provider.init();
-
-            verify(mockSingleton).connect();
         }
     }
 
@@ -210,8 +200,8 @@ public class MqttClientProviderTest {
     public void testReconnectConfiguration() throws Exception {
         Map<String, Object> reconnect = new HashMap<>();
         reconnect.put("enabled", false);
-        reconnect.put("initial-delay-ms", 2000);
-        reconnect.put("max-delay-ms", 60000);
+        reconnect.put("initial-delay-ms", 2000L);
+        reconnect.put("max-delay-ms", 60000L);
         config.put("reconnect", reconnect);
         callInitWithoutConnection();
 
@@ -229,7 +219,7 @@ public class MqttClientProviderTest {
         will.put("qos", 1);
         will.put("retain", true);
         config.put("will", will);
-        // config.put("protocol-version", 3);
+        config.put("protocol-version", 3);
         callInitWithoutConnection();
 
         assertEquals("device/status", getSingletonField("willTopic"));
@@ -248,10 +238,10 @@ public class MqttClientProviderTest {
         will.put("payload", "offline");
         will.put("qos", 2);
         will.put("retain", false);
-        will.put("delay-seconds", 30);
-        will.put("message-expiry-seconds", 3600);
+        will.put("delay-seconds", 30L);
+        will.put("message-expiry-seconds", 3600L);
         config.put("will", will);
-        // config.put("protocol-version", 5);
+        config.put("protocol-version", 5);
         callInitWithoutConnection();
 
         assertEquals("device/status", getSingletonField("willTopic"));
@@ -259,7 +249,7 @@ public class MqttClientProviderTest {
         assertEquals(2, getSingletonField("willQos"));
         assertEquals(false, getSingletonField("willRetain"));
         assertEquals(30L, getSingletonField("willDelaySeconds"));
-        assertEquals(3600, getSingletonField("willMessageExpirySeconds"));
+        assertEquals(3600L, getSingletonField("willMessageExpirySeconds"));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
     </properties>
 
     <modules>
+        <module>mqtt</module>
         <module>test-plugins</module>
         <module>commons</module>
         <module>mongoclient</module>


### PR DESCRIPTION
Introduces MQTT module phase 1 for Issue : #601.
Most of the design remains same as mentioned in the issue, except :
1 ) Added support for session expiry (MQTT5 only), by default the subscibers will be durable with cleanSession false and session expiry as max value (session never expires) which makes sure messages are not lost in case of disconnection / reconnections
2) Added support for will messages with will delay and will message expiry for MQTT 5
3) Added MqttConfig builder class which encapsulates all configuration parameters needed to initialize an MQTT client connection


MqttClientProviderTest contains unit tests for Config parsing, `@OnInit` option building, TLS config. Tests verify that the provider correctly parses configuration and initializes MqttClientSingleton with the expected values.