### PR TITLE
feat: MQTT client module phase 2

### DIFF
--- a/mqtt/pom.xml
+++ b/mqtt/pom.xml
@@ -93,6 +93,18 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>license-maven-plugin</artifactId>
         <configuration>

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttClientProvider.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttClientProvider.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * restheart-mongoclient-provider
+ * restheart-mqtt
  * %%
  * Copyright (C) 2014 - 2026 SoftInstigate
  * %%

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttClientSingleton.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttClientSingleton.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * restheart-mongoclient-provider
+ * restheart-mqtt
  * %%
  * Copyright (C) 2014 - 2026 SoftInstigate
  * %%
@@ -39,6 +39,8 @@ import com.hivemq.client.mqtt.mqtt3.Mqtt3AsyncClient;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3ClientBuilder;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientBuilder;
+import com.hivemq.client.mqtt.mqtt5.lifecycle.Mqtt5ClientConnectedContext;
+import com.hivemq.client.util.TypeSwitch;
 
 /**
  * Thread-safe singleton that manages the lifecycle of a MQTT client  {@link MqttClient}.
@@ -294,7 +296,19 @@ public class MqttClientSingleton {
             builder.automaticReconnect()
                 .initialDelay(initialDelayMs, TimeUnit.MILLISECONDS)
                 .maxDelay(maxDelayMs, TimeUnit.MILLISECONDS)
-                .applyAutomaticReconnect();
+                .applyAutomaticReconnect()
+                .addConnectedListener(context -> {
+                    // Resubscribe to topic filters if session is not present
+                    TypeSwitch.when(context)
+                    .is(Mqtt5ClientConnectedContext.class, q -> {
+                        if (!q.getConnAck().isSessionPresent()) {
+                            LOGGER.info("New session detected (sessionPresent=false), triggering resubscription");
+                            MqttMessageRouter.getInstance().resubscribeAll();
+                        } else {
+                            LOGGER.info("Existing session detected (sessionPresent=true), skipping resubscription");
+                        }
+                    });
+                });
         }
 
         if (tlsEnabled) {
@@ -341,7 +355,19 @@ public class MqttClientSingleton {
             builder.automaticReconnect()
                 .initialDelay(initialDelayMs, TimeUnit.MILLISECONDS)
                 .maxDelay(maxDelayMs, TimeUnit.MILLISECONDS)
-                .applyAutomaticReconnect();
+                .applyAutomaticReconnect()
+                .addConnectedListener(context -> {
+                    // Resubscribe to topic filters if session is not present
+                    TypeSwitch.when(context)
+                    .is(Mqtt5ClientConnectedContext.class, q -> {
+                        if (!q.getConnAck().isSessionPresent()) {
+                            LOGGER.info("New session detected (sessionPresent=false), triggering resubscription");
+                            MqttMessageRouter.getInstance().resubscribeAll();
+                        } else {
+                            LOGGER.info("Existing session detected (sessionPresent=true), skipping resubscription");
+                        }
+                    });
+                });
         }
 
         // Configure TLS if enabled

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttClientSingleton.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttClientSingleton.java
@@ -37,6 +37,7 @@ import com.hivemq.client.mqtt.MqttClient;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3AsyncClient;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3ClientBuilder;
+import com.hivemq.client.mqtt.mqtt3.lifecycle.Mqtt3ClientConnectedContext;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientBuilder;
 import com.hivemq.client.mqtt.mqtt5.lifecycle.Mqtt5ClientConnectedContext;
@@ -359,7 +360,7 @@ public class MqttClientSingleton {
                 .addConnectedListener(context -> {
                     // Resubscribe to topic filters if session is not present
                     TypeSwitch.when(context)
-                    .is(Mqtt5ClientConnectedContext.class, q -> {
+                    .is(Mqtt3ClientConnectedContext.class, q -> {
                         if (!q.getConnAck().isSessionPresent()) {
                             LOGGER.info("New session detected (sessionPresent=false), triggering resubscription");
                             MqttMessageRouter.getInstance().resubscribeAll();

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttConfig.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttConfig.java
@@ -1,6 +1,6 @@
 /*-
  * ========================LICENSE_START=================================
- * restheart-mongoclient-provider
+ * restheart-mqtt
  * %%
  * Copyright (C) 2014 - 2026 SoftInstigate
  * %%

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttMessage.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttMessage.java
@@ -1,0 +1,93 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-mqtt
+ * %%
+ * Copyright (C) 2014 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+package org.restheart.mqtt;
+
+import java.time.Instant;
+
+/**
+ * POJO representing an MQTT message received from the broker.
+ *
+ * This immutable class encapsulates the essential properties of an MQTT message:
+ * - Topic: The MQTT topic the message was published to
+ * - Payload: The message content as a UTF-8 string
+ * - QoS: Quality of Service level (0, 1, or 2)
+ * - ReceivedAt: Timestamp when the message was received by RESTHeart
+ *
+ * Instances are created by the MqttMessageRouter when messages arrive from
+ * the broker and are distributed to registered listeners.
+ *
+ * @author Harshit Sharma {@literal <harshitsharma635@gmail.com>}
+ */
+public class MqttMessage {
+    private final String topic;
+    private final String payload;
+    private final int qos;
+    private final Instant receivedAt;
+
+    /**
+     * Create a new MQTT message
+     *
+     * @param topic The MQTT topic
+     * @param payload The message payload as UTF-8 string
+     * @param qos Quality of Service level (0, 1, or 2)
+     * @param receivedAt Timestamp when message was received
+     */
+    public MqttMessage(String topic, String payload, int qos, Instant receivedAt) {
+        this.topic = topic;
+        this.payload = payload;
+        this.qos = qos;
+        this.receivedAt = receivedAt;
+    }
+
+    /**
+     * @return The MQTT topic
+     */
+    public String getTopic() {
+        return topic;
+    }
+
+    /**
+     * @return The message payload as UTF-8 string
+     */
+    public String getPayload() {
+        return payload;
+    }
+
+    /**
+     * @return Quality of Service level (0, 1, or 2)
+     */
+    public int getQos() {
+        return qos;
+    }
+
+    /**
+     * @return Timestamp when message was received
+     */
+    public Instant getReceivedAt() {
+        return receivedAt;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("MqttMessage{topic='%s', qos=%d, receivedAt=%s, payload='%s'}",
+            topic, qos, receivedAt, payload);
+    }
+}

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttMessageRouter.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttMessageRouter.java
@@ -407,7 +407,7 @@ public class MqttMessageRouter {
         }
 
         String[] topicLevels = topic.split("/");
-        String[] topicFilterLevels = topic.split("/");
+        String[] topicFilterLevels = topicFilter.split("/");
 
         // Multi-level wildcard (#) must be last
         if (topicFilter.endsWith("/#")) {

--- a/mqtt/src/main/java/org/restheart/mqtt/MqttMessageRouter.java
+++ b/mqtt/src/main/java/org/restheart/mqtt/MqttMessageRouter.java
@@ -1,0 +1,565 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-mqtt
+ * %%
+ * Copyright (C) 2014 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+
+package org.restheart.mqtt;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.hivemq.client.mqtt.MqttClient;
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.mqtt3.Mqtt3AsyncClient;
+import com.hivemq.client.mqtt.mqtt3.message.publish.Mqtt3Publish;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
+
+/**
+ * Singleton router that bridges an underlying MQTT broker connection (MQTT 3 or 5, via the
+ * HiveMQ client) to in-process listeners.
+ * <p>
+ * Consumers register interest in a topic filter via {@link #subscribe(String, MqttQos, Consumer)};
+ * the router lazily subscribes to the broker the first time a topic filter gains a listener, and
+ * unsubscribes from the broker once the last listener for a topic filter is removed. Incoming
+ * broker messages are converted to {@link MqttMessage} instances, optionally cached for late
+ * joiners, and dispatched to all matching listeners on a virtual thread.
+ * <p>
+ * The router also applies a simple per-second rate limit to protect against message floods, and
+ * exposes basic {@link RouterStats runtime statistics}.
+ * <p>
+ * This class is thread-safe: internal state is held in concurrent collections and atomic
+ * counters, and it is accessed as a process-wide singleton via {@link #getInstance()}.
+ * 
+ * @author Harshit Sharma {@literal <harshitsharma635@gmail.com>}
+ */
+public class MqttMessageRouter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MqttMessageRouter.class);
+
+    // Topic filter -> list of message consumers
+    private final Map<String, List<Consumer<MqttMessage>>> listeners = new ConcurrentHashMap<>();
+
+    // Topic -> last message cache (for late joiners)
+    private final Map<String, MqttMessage> lastMessageCache = new ConcurrentHashMap<>();
+
+    // Rate Limiting
+    private final AtomicLong messageCount = new AtomicLong(0);
+    private final AtomicLong droppedCount = new AtomicLong(0);
+    private volatile long lastResetTime = System.currentTimeMillis();
+    private volatile int maxMessagePerSecond = 5000; // Default, configurable
+
+    // Configuration
+    private volatile boolean cacheEnabled = true;
+    private volatile int maxCacheSize = 1000;
+
+    private final AtomicBoolean initialized = new AtomicBoolean(false);
+
+    /**
+     * Returns the process-wide singleton instance of the router.
+     * <p>
+     * The instance is created lazily and stashed in a system property keyed by the class name so
+     * that a single instance is shared even across multiple classloaders (see
+     * {@link MqttMessageRouterHolder}).
+     *
+     * @return the singleton {@code MqttMessageRouter} instance
+     */
+    public static MqttMessageRouter getInstance() {
+        return MqttMessageRouterHolder.INSTANCE;
+    }
+
+    private MqttMessageRouter() {
+        // Private constructor for singleton
+    }
+
+    /**
+     * Initializes the router's configuration. This must be called once before the router is
+     * used; subsequent calls are ignored (and logged as a warning) so that configuration cannot
+     * be silently changed after startup.
+     *
+     * @param maxMessagePerSecond the maximum number of messages accepted per second before
+     *                            further messages are dropped; a value {@code <= 0} disables the
+     *                            rate limit
+     * @param cacheEnabled        whether the last message received per topic should be cached for
+     *                            late-joining subscribers
+     * @param maxCacheSize        the maximum number of topics to retain in the last-message cache
+     *                            when caching is enabled
+     */
+    public void init(int maxMessagePerSecond, boolean cacheEnabled, int maxCacheSize) {
+        if (!initialized.compareAndSet(false, true)) {
+            LOGGER.warn("MqttMessageRouter already initialized, ignoring duplicate init call");
+            return;
+        }
+        this.maxMessagePerSecond = maxMessagePerSecond;
+        this.maxCacheSize = maxCacheSize;
+        this.cacheEnabled = cacheEnabled;
+
+        LOGGER.info("MqttMessageRouter initialized: maxRate={}/s, cache={}, maxCacheSize={}", 
+        maxMessagePerSecond, cacheEnabled, maxCacheSize);
+    }
+
+    /**
+     * Registers a listener for messages published on topics matching the given topic filter.
+     * <p>
+     * If this is the first listener registered for {@code topicFilter}, the router subscribes to
+     * the filter on the underlying broker connection with the given QoS.
+     *
+     * @param topicFilter the MQTT topic filter to listen on (may contain {@code +} and
+     *                    {@code #} wildcards)
+     * @param qos         the QoS level to use when subscribing to the broker
+     * @param listener    the callback invoked with each {@link MqttMessage} matching the filter
+     */
+    public void subscribe(String topicFilter, MqttQos qos, Consumer<MqttMessage> listener) {
+        listeners.computeIfAbsent(topicFilter, k -> new CopyOnWriteArrayList<>()).add(listener);
+
+        // Subscribe to broker if this is the first listener for this topic
+        if (listeners.get(topicFilter).size() == 1) {
+            subscribeOnBroker(topicFilter, qos);
+        }
+
+        LOGGER.debug("Added listener for topic filter: {}, total listeners: {}", 
+        topicFilter, listeners.get(topicFilter).size());
+    }
+
+    /**
+     * Removes a previously registered listener for the given topic filter.
+     * <p>
+     * If this was the last listener registered for {@code topicFilter}, the router unsubscribes
+     * from the filter on the underlying broker connection.
+     *
+     * @param topicFilter the MQTT topic filter the listener was registered on
+     * @param listener    the listener instance to remove
+     */
+    public void unsubscribe(String topicFilter, Consumer<MqttMessage> listener) {
+        List<Consumer<MqttMessage>> topicListeners = listeners.get(topicFilter);
+        if (topicListeners != null) {
+            topicListeners.remove(listener);
+
+            // If no more listeners, unsubscribe from broker
+            if (topicListeners.isEmpty()) {
+                listeners.remove(topicFilter);
+                unsubscribeFromBroker(topicFilter);
+            }
+
+            LOGGER.debug("Removed listener for topic filter: {}, remaining: {}"
+                , topicFilter, topicListeners.size());
+        }
+    }
+
+    /**
+     * Issues a subscribe request for the given topic filter against the underlying MQTT client,
+     * dispatching to the MQTT 5 or MQTT 3 API depending on the client type in use. The
+     * appropriate {@code handleMqtt5Message}/{@code handleMqtt3Message} callback is wired in as
+     * the message handler for the subscription.
+     *
+     * @param topicFilter the MQTT topic filter to subscribe to
+     * @param qos         the QoS level to subscribe with
+     */
+    private void subscribeOnBroker(String topicFilter, MqttQos qos) {
+        MqttClient client = MqttClientSingleton.getInstance().getClient();
+
+        if (client instanceof Mqtt5AsyncClient) {
+            ((Mqtt5AsyncClient)client).subscribeWith()
+                .topicFilter(topicFilter)
+                .qos(qos)
+                .callback(this::handleMqtt5Message)
+                .send()
+                .whenComplete((subAck, throwable) -> {
+                    if (throwable != null) {
+                        LOGGER.error("Failed to subscribe to topic filter: {}", topicFilter, throwable);
+                    } else {
+                        LOGGER.info("Subscribed to topic filter: {} with QoS {}", topicFilter, qos);
+                    }
+            });
+        } else if (client instanceof Mqtt3AsyncClient) {
+            ((Mqtt3AsyncClient) client).subscribeWith()
+                .topicFilter(topicFilter)
+                .qos(qos)
+                .callback(this::handleMqtt3Message)
+                .send()
+                .whenComplete((subAck, throwable) -> {
+                    if (throwable != null) {
+                        LOGGER.error("Failed to subscribe to topic filter: {}", topicFilter, throwable);
+                    } else {
+                        LOGGER.info("Subscribed to topic filter: {} with QoS {}", topicFilter, qos);
+                    }
+                });
+        }
+    }
+
+    /**
+     * Issues an unsubscribe request for the given topic filter against the underlying MQTT
+     * client, dispatching to the MQTT 5 or MQTT 3 API depending on the client type in use.
+     *
+     * @param topicFilter the MQTT topic filter to unsubscribe from
+     */
+    private void unsubscribeFromBroker(String topicFilter) {
+        MqttClient client = MqttClientSingleton.getInstance().getClient();
+
+        if (client instanceof Mqtt5AsyncClient) {
+            ((Mqtt5AsyncClient) client).unsubscribeWith()
+                .topicFilter(topicFilter)
+                .send()
+                .whenComplete((unsubAck, throwable) -> {
+                    if (throwable != null) {
+                        LOGGER.error("Failed to unsubscribe to topic filter: {}", topicFilter, throwable);
+                    } else {
+                        LOGGER.info("Unsubscribed to topic filter: {} with QoS {}", topicFilter);
+                    }
+                });
+        } else if (client instanceof Mqtt3AsyncClient) {
+            ((Mqtt3AsyncClient) client).unsubscribeWith()
+                .topicFilter(topicFilter)
+                .send()
+                .whenComplete((unsubAck, throwable) -> {
+                    if (throwable != null) {
+                        LOGGER.error("Failed to unsubscribe to topic filter: {}", topicFilter, throwable);
+                    } else {
+                        LOGGER.info("Unsubscribed to topic filter: {} with QoS {}", topicFilter);
+                    }
+                });
+        }
+    }
+
+    /**
+     * Handles an incoming MQTT 5 publish: applies the rate limit, converts the publish to an
+     * internal {@link MqttMessage}, updates the last-message cache if enabled, and dispatches the
+     * message to matching listeners on a new virtual thread.
+     *
+     * @param publish the MQTT 5 publish received from the broker
+     */
+    private void handleMqtt5Message(Mqtt5Publish publish) {
+        // Check rate limit
+        if (!checkRateLimit()) {
+            droppedCount.incrementAndGet();
+            if (droppedCount.get() % 1000 == 0) {
+                LOGGER.warn("Rate limit exceeded, dropped {} messages", droppedCount.get());
+            }
+            return;
+        }
+
+        // Convert to internal message format
+        MqttMessage message = new MqttMessage(
+            publish.getTopic().toString(),
+            new String(publish.getPayloadAsBytes(), StandardCharsets.UTF_8),
+            publish.getQos().getCode(),
+            Instant.now()
+        );
+
+        // Update cache
+        if (cacheEnabled) {
+            updateCache(message);
+        }
+
+        // Dispatch on virtual thread
+        Thread.ofVirtual().start(() -> dispatchMessage(message));
+
+    }
+
+    /**
+     * Handles an incoming MQTT 3 publish: applies the rate limit, converts the publish to an
+     * internal {@link MqttMessage}, updates the last-message cache if enabled, and dispatches the
+     * message to matching listeners on a new virtual thread.
+     *
+     * @param publish the MQTT 3 publish received from the broker
+     */
+    private void handleMqtt3Message(Mqtt3Publish publish) {
+        // Check rate limit
+        if (!checkRateLimit()) {
+            droppedCount.incrementAndGet();
+            if (droppedCount.get() % 1000 == 0) {
+                LOGGER.warn("Rate limit exceeded, dropped {} messages", droppedCount.get());
+            }
+            return;
+        }
+
+        // Convert to internal message format
+        MqttMessage message = new MqttMessage(
+            publish.getTopic().toString(),
+            new String(publish.getPayloadAsBytes(), StandardCharsets.UTF_8),
+            publish.getQos().getCode(),
+            Instant.now()
+        );
+
+        // Update cache
+        if (cacheEnabled) {
+            updateCache(message);
+        }
+
+        // Dispatch on virtual thread
+        Thread.ofVirtual().start(() -> dispatchMessage(message));
+
+    }
+
+    /**
+     * Enforces the configured per-second message rate limit, resetting the counter once a second
+     * has elapsed since the last reset.
+     *
+     * @return {@code true} if the current message is within the allowed rate (or rate limiting is
+     *         disabled because {@code maxMessagePerSecond <= 0}), {@code false} if it should be
+     *         dropped
+     */
+    private boolean checkRateLimit() {
+        if (maxMessagePerSecond <= 0) {
+            return true; // No limit
+        }
+
+        long now = System.currentTimeMillis();
+        long elapsed = now - lastResetTime;
+
+        // Reset counter every second
+        if (elapsed >= 1000) {
+            synchronized (this) {
+                if (elapsed >= 1000) {
+                    messageCount.set(0);
+                    lastResetTime = now;
+                }
+            }
+        }
+
+        return messageCount.incrementAndGet() <= maxMessagePerSecond;
+    }
+
+    /**
+     * Stores the given message as the last received message for its topic, evicting an arbitrary
+     * existing entry first if the cache is already at {@link #maxCacheSize}.
+     * <p>
+     * Note: eviction is not LRU-based; it simply removes whichever entry the map's iterator
+     * returns first.
+     *
+     * @param message the message to cache, keyed by {@link MqttMessage#getTopic()}
+     */
+    private void updateCache(MqttMessage message) {
+        if (lastMessageCache.size() >= maxCacheSize) {
+            // Simmple eviction: remove first entry (not LRU, but good enough)
+            String firstKey = lastMessageCache.keySet().iterator().next();
+            lastMessageCache.remove(firstKey);
+        }
+
+        lastMessageCache.put(message.getTopic(), message);
+    }
+
+    /**
+     * Dispatches a received message to every registered listener whose topic filter matches the
+     * message's topic. Exceptions thrown by individual listeners are caught and logged so that a
+     * failing listener does not prevent delivery to other listeners.
+     *
+     * @param message the message to dispatch
+     */
+    private void dispatchMessage(MqttMessage message) {
+        for (Map.Entry<String, List<Consumer<MqttMessage>>> entry : listeners.entrySet()) {
+            String topicFilter = entry.getKey();
+
+            // Check if message topic matches the filter
+            if (topicMatches(message.getTopic(), topicFilter)) {
+                for (Consumer<MqttMessage> listener : entry.getValue()) {
+                    try {
+                        listener.accept(message);
+                    } catch (Exception e) {
+                        LOGGER.error("Error dispatching message to listener for topic {}", 
+                            message.getTopic());
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Determines whether a concrete MQTT topic matches a topic filter, following standard MQTT
+     * matching rules: exact matches, the single-level wildcard {@code +}, and the multi-level
+     * wildcard {@code #} (which must appear as the final level of the filter).
+     *
+     * @param topic       the concrete topic a message was published on
+     * @param topicFilter the topic filter (possibly containing {@code +}/{@code #} wildcards) to
+     *                    match against
+     * @return {@code true} if {@code topic} matches {@code topicFilter}, {@code false} otherwise
+     */
+    private boolean topicMatches(String topic, String topicFilter) {
+        // Exact match
+        if (topic.equals(topicFilter)) {
+            return true;
+        }
+
+        String[] topicLevels = topic.split("/");
+        String[] topicFilterLevels = topic.split("/");
+
+        // Multi-level wildcard (#) must be last
+        if (topicFilter.endsWith("/#")) {
+            String prefix = topicFilter.substring(0, topicFilter.length() - 2);
+            return topic.startsWith(prefix);
+        }
+
+        // Different number of level (and no multi-level wildcard)
+        if (topicLevels.length != topicFilterLevels.length) {
+            return false;
+        }
+
+        // Check each level
+        for (int i = 0; i < topicFilterLevels.length; i++) {
+            String filterLevel = topicFilterLevels[i];
+            String topicLevel = topicLevels[i];
+
+            // Single-level wildcard (+) matches any single level
+            if (filterLevel.equals("+")) {
+                continue;
+            }
+
+            // Exact match required
+            if (!filterLevel.equals(topicLevel)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns the last message received for the given topic, if caching is enabled and a message
+     * has been received and retained for it.
+     *
+     * @param topic the exact topic to look up
+     * @return the last cached {@link MqttMessage} for {@code topic}, or {@code null} if none is
+     *         cached
+     */
+    public MqttMessage getLastMessage(String topic) {
+        return lastMessageCache.get(topic);
+    }
+
+    /**
+     * Re-issues broker subscriptions for every topic filter that currently has registered
+     * listeners. Intended to be called after the underlying MQTT client reconnects, since broker
+     * subscriptions do not survive a disconnect.
+     * <p>
+     * All re-subscriptions are made with QoS {@link MqttQos#AT_LEAST_ONCE}, regardless of the QoS
+     * originally requested by each listener.
+     */
+    public void resubscribeAll() {
+        LOGGER.info("Re-subscribing to {} topic filters after reconnect", listeners.size());
+
+        for (String topicFilter : listeners.keySet()) {
+            // Use default QoS 1 for re-subscription
+            subscribeOnBroker(topicFilter, MqttQos.AT_LEAST_ONCE);
+        }
+    }
+
+    /**
+     * Get statistics
+     *
+     * @return a snapshot of the router's current runtime statistics
+     */
+    public RouterStats getStats() {
+        return new RouterStats(
+            listeners.size(),
+            listeners.values().stream().mapToInt(List::size).sum(),
+            lastMessageCache.size(),
+            messageCount.get(),
+            droppedCount.get()
+        );
+    }
+
+    /**
+     * Statistics holder
+     */
+    public static class RouterStats {
+        private final int topicFilters;
+        private final int totalListeners;
+        private final int cachedMessages;
+        private final long messagesReceived;
+        private final long messagesDropped;
+
+        /**
+         * Creates a new immutable statistics snapshot.
+         *
+         * @param topicFilters     the number of distinct topic filters currently subscribed
+         * @param totalListeners   the total number of listeners registered across all topic filters
+         * @param cachedMessages   the number of topics currently present in the last-message cache
+         * @param messagesReceived the number of messages counted toward the current rate-limit window
+         * @param messagesDropped  the cumulative number of messages dropped due to rate limiting
+         */
+        public RouterStats(int topicFilters, int totalListeners, int cachedMessages,
+                          long messagesReceived, long messagesDropped) {
+            this.topicFilters = topicFilters;
+            this.totalListeners = totalListeners;
+            this.cachedMessages = cachedMessages;
+            this.messagesReceived = messagesReceived;
+            this.messagesDropped = messagesDropped;
+        }
+
+        /**
+         * @return the number of distinct topic filters currently subscribed
+         */
+        public int getTopicFilters() { return topicFilters; }
+
+        /**
+         * @return the total number of listeners registered across all topic filters
+         */
+        public int getTotalListeners() { return totalListeners; }
+
+        /**
+         * @return the number of topics currently present in the last-message cache
+         */
+        public int getCachedMessages() { return cachedMessages; }
+
+        /**
+         * @return the number of messages counted toward the current rate-limit window
+         */
+        public long getMessagesReceived() { return messagesReceived; }
+
+        /**
+         * @return the cumulative number of messages dropped due to rate limiting
+         */
+        public long getMessagesDropped() { return messagesDropped; }
+    }
+
+    /**
+     * Lazy holder that creates (or reuses) the {@link MqttMessageRouter} singleton.
+     * <p>
+     * The instance is stored in a system property keyed by the class name so that if this class
+     * is loaded by more than one classloader, all loads share the same underlying router
+     * instance rather than creating independent singletons.
+     */
+    private static class MqttMessageRouterHolder {
+        private static final MqttMessageRouter INSTANCE;
+
+        static {
+            synchronized (ClassLoader.getSystemClassLoader()) {
+                final var sysProps = System.getProperties();
+                final var singleton = (MqttMessageRouter) sysProps.get(MqttMessageRouter.class.getName());
+
+                if (singleton != null) {
+                    INSTANCE = singleton;
+                } else {
+                    INSTANCE = new MqttMessageRouter();
+                    System.getProperties().put(MqttMessageRouter.class.getName(), INSTANCE);
+                }
+            }
+        }
+        
+    }
+}

--- a/mqtt/src/test/java/org/restheart/mqtt/MqttMessageRouterTest.java
+++ b/mqtt/src/test/java/org/restheart/mqtt/MqttMessageRouterTest.java
@@ -1,0 +1,229 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-mongoclient-provider
+ * %%
+ * Copyright (C) 2014 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+package org.restheart.mqtt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.restheart.mqtt.MqttMessageRouter.RouterStats;
+
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
+
+/**
+ * Unit tests for MqttMessageRouter
+ * Tests verify that the router correctly handles subscription and unsubscription logic.
+ *
+ * @author Harshit Sharma {@literal <harshitsharma635@gmail.com>}
+ */
+public class MqttMessageRouterTest {
+
+    private MqttMessageRouter router;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() throws Exception {
+        router = MqttMessageRouter.getInstance();
+
+        // Clear listeners
+        Field listenersField = MqttMessageRouter.class.getDeclaredField("listeners");
+        listenersField.setAccessible(true);
+        ((Map<?, ?>) listenersField.get(router)).clear();
+
+        // Clear cache
+        Field cacheField = MqttMessageRouter.class.getDeclaredField("lastMessageCache");
+        cacheField.setAccessible(true);
+        ((Map<?, ?>) cacheField.get(router)).clear();
+
+        // Reset rate limiter
+        Field messageCountField = MqttMessageRouter.class.getDeclaredField("messageCount");
+        messageCountField.setAccessible(true);
+        ((AtomicLong) messageCountField.get(router)).set(0);
+
+        Field droppedCountField = MqttMessageRouter.class.getDeclaredField("droppedCount");
+        droppedCountField.setAccessible(true);
+        ((AtomicLong) droppedCountField.get(router)).set(0);
+
+        // Re-init with defaults
+        Field initField = MqttMessageRouter.class.getDeclaredField("initialized");
+        initField.setAccessible(true);
+        ((AtomicBoolean) initField.get(router)).set(false);
+
+        router.init(5000, true, 1000);
+    }
+
+    @Test
+    void testSubscribeAndUnsubscribe() {
+        try (MockedStatic<MqttClientSingleton> singletonMock = mockStatic(MqttClientSingleton.class)) {
+            MqttClientSingleton mockInstance = mock(MqttClientSingleton.class);
+            Mqtt5AsyncClient mockClient = mock(Mqtt5AsyncClient.class);
+            
+            when(mockClient.subscribeWith()).thenThrow(new RuntimeException("SubscribeCalled"));
+            when(mockClient.unsubscribeWith()).thenThrow(new RuntimeException("UnsubscribeCalled"));
+
+            when(mockInstance.getClient()).thenReturn(mockClient);
+            singletonMock.when(MqttClientSingleton::getInstance).thenReturn(mockInstance);
+
+            Consumer<MqttMessage> listener1 = msg -> {};
+            Consumer<MqttMessage> listener2 = msg -> {};
+
+            // 1st listener -> triggers subscribeOnBroker
+            RuntimeException ex1 = assertThrows(RuntimeException.class, 
+                () -> router.subscribe("test/topic", MqttQos.AT_LEAST_ONCE, listener1));
+            assertEquals("SubscribeCalled", ex1.getMessage());
+
+            // 2nd listener on same topic -> does NOT trigger subscribeOnBroker again
+            router.subscribe("test/topic", MqttQos.AT_LEAST_ONCE, listener2);
+
+            // Unsubscribe listener1 -> does NOT trigger unsubscribeFromBroker
+            router.unsubscribe("test/topic", listener1);
+
+            // Unsubscribe listener2 -> last listener, triggers unsubscribeFromBroker
+            RuntimeException ex2 = assertThrows(RuntimeException.class, 
+                () -> router.unsubscribe("test/topic", listener2));
+            assertEquals("UnsubscribeCalled", ex2.getMessage());
+            
+            // Verify stats
+            RouterStats stats = router.getStats();
+            assertEquals(0, stats.getTopicFilters());
+            assertEquals(0, stats.getTotalListeners());
+        }
+    }
+
+    @Test
+    void testTopicMatching() throws Exception {
+        Method topicMatchesMethod = MqttMessageRouter.class.getDeclaredMethod("topicMatches", String.class, String.class);
+        topicMatchesMethod.setAccessible(true);
+
+        // Exact match
+        assertTrue((Boolean) topicMatchesMethod.invoke(router, "sensors/temp", "sensors/temp"));
+        assertFalse((Boolean) topicMatchesMethod.invoke(router, "sensors/temp", "sensors/hum"));
+
+        // Single level wildcard (+)
+        assertTrue((Boolean) topicMatchesMethod.invoke(router, "sensors/temp", "sensors/+"));
+        assertTrue((Boolean) topicMatchesMethod.invoke(router, "sensors/hum", "sensors/+"));
+        assertFalse((Boolean) topicMatchesMethod.invoke(router, "sensors/temp/1", "sensors/+"));
+
+        // Multi-level wildcard (#)
+        assertTrue((Boolean) topicMatchesMethod.invoke(router, "sensors/temp", "sensors/#"));
+        assertTrue((Boolean) topicMatchesMethod.invoke(router, "sensors/temp/1", "sensors/#"));
+        assertFalse((Boolean) topicMatchesMethod.invoke(router, "system/temp", "sensors/#"));
+        
+        // Single level wildcards embedded
+        assertTrue((Boolean) topicMatchesMethod.invoke(router, "a/b", "+/+"));
+    }
+
+    @Test
+    void testRateLimitEnforcement() throws Exception {
+        // Re-init with limit = 2 msgs per second
+        Field initField = MqttMessageRouter.class.getDeclaredField("initialized");
+        initField.setAccessible(true);
+        ((AtomicBoolean) initField.get(router)).set(false);
+        router.init(2, true, 1000);
+
+        Method checkRateLimitMethod = MqttMessageRouter.class.getDeclaredMethod("checkRateLimit");
+        checkRateLimitMethod.setAccessible(true);
+
+        // First 2 should pass
+        assertTrue((Boolean) checkRateLimitMethod.invoke(router));
+        assertTrue((Boolean) checkRateLimitMethod.invoke(router));
+        
+        // 3rd should fail
+        assertFalse((Boolean) checkRateLimitMethod.invoke(router));
+        assertFalse((Boolean) checkRateLimitMethod.invoke(router));
+
+        // Sleep 1 second
+        Thread.sleep(1050);
+
+        // Should pass again
+        assertTrue((Boolean) checkRateLimitMethod.invoke(router));
+    }
+
+    @Test
+    void testFanoutOrderingAndDispatch() throws Exception {
+        // We will simulate `dispatchMessage` and verify listeners are called in order.
+        List<String> invocationOrder = new ArrayList<>();
+
+        Consumer<MqttMessage> listenerA = msg -> invocationOrder.add("A");
+        Consumer<MqttMessage> listenerB = msg -> invocationOrder.add("B");
+        Consumer<MqttMessage> listenerC = msg -> invocationOrder.add("C");
+
+        try (MockedStatic<MqttClientSingleton> singletonMock = mockStatic(MqttClientSingleton.class)) {
+            MqttClientSingleton mockInstance = mock(MqttClientSingleton.class);
+            Mqtt5AsyncClient mockClient = mock(Mqtt5AsyncClient.class);
+            when(mockClient.subscribeWith()).thenThrow(new RuntimeException("Ignored"));
+            when(mockInstance.getClient()).thenReturn(mockClient);
+            singletonMock.when(MqttClientSingleton::getInstance).thenReturn(mockInstance);
+
+            try {
+                router.subscribe("test/order", MqttQos.AT_LEAST_ONCE, listenerA);
+            } catch (RuntimeException e) {}
+            router.subscribe("test/order", MqttQos.AT_LEAST_ONCE, listenerB);
+            router.subscribe("test/order", MqttQos.AT_LEAST_ONCE, listenerC);
+        }
+
+        MqttMessage message = new MqttMessage("test/order", "payload", 1, Instant.now());
+
+        Method dispatchMessageMethod = MqttMessageRouter.class.getDeclaredMethod("dispatchMessage", MqttMessage.class);
+        dispatchMessageMethod.setAccessible(true);
+        dispatchMessageMethod.invoke(router, message);
+
+        assertEquals(3, invocationOrder.size());
+        assertEquals("A", invocationOrder.get(0));
+        assertEquals("B", invocationOrder.get(1));
+        assertEquals("C", invocationOrder.get(2));
+    }
+
+    @Test
+    void testLastMessageCache() throws Exception {
+        MqttMessage message = new MqttMessage("test/cache", "payload", 1, Instant.now());
+        
+        Method updateCacheMethod = MqttMessageRouter.class.getDeclaredMethod("updateCache", MqttMessage.class);
+        updateCacheMethod.setAccessible(true);
+        updateCacheMethod.invoke(router, message);
+
+        MqttMessage cached = router.getLastMessage("test/cache");
+        assertNotNull(cached);
+        assertEquals("payload", cached.getPayload());
+        assertEquals("test/cache", cached.getTopic());
+    }
+}
+

--- a/mqtt/src/test/java/org/restheart/mqtt/MqttReconnectIT.java
+++ b/mqtt/src/test/java/org/restheart/mqtt/MqttReconnectIT.java
@@ -1,0 +1,231 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-mqtt
+ * %%
+ * Copyright (C) 2014 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+
+package org.restheart.mqtt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.moquette.BrokerConstants;
+import io.moquette.broker.Server;
+import io.moquette.broker.config.MemoryConfig;
+
+import com.hivemq.client.mqtt.MqttClient;
+import com.hivemq.client.mqtt.MqttClientState;
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.mqtt3.Mqtt3AsyncClient;
+
+/**
+ * Integration test for MQTT Client automatic reconnection.
+ * Starts Moquette as an embedded broker, connects, stops and restarts the broker,
+ * and asserts that the connection is restored and subscriptions are active.
+ * 
+ * @author Harshit Sharma {@literal <harshitsharma635@gmail.com>}
+ */
+public class MqttReconnectIT {
+
+    private static Server server;
+    private static int brokerPort;
+    private static Properties brokerProps;
+
+    private MqttMessageRouter router;
+
+    @BeforeAll
+    static void startBroker() throws Exception {
+        brokerProps = new Properties();
+        brokerProps.setProperty(BrokerConstants.PORT_PROPERTY_NAME, "1883");  // random port
+        brokerProps.setProperty(BrokerConstants.HOST_PROPERTY_NAME, "localhost");
+        brokerProps.setProperty(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, "true");
+        brokerProps.setProperty(BrokerConstants.PERSISTENCE_ENABLED_PROPERTY_NAME, "false");
+
+        server = new Server();
+        server.startServer(new MemoryConfig(brokerProps));
+        brokerPort = server.getPort();
+    }
+
+    @AfterAll
+    static void stopBroker() {
+        if (server != null) {
+            try {
+                server.stopServer();
+            } catch (Exception e) {
+                // Ignore
+            }
+        }
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        // Reset singletons using reflection
+        resetSingletons();
+
+        router = MqttMessageRouter.getInstance();
+        router.init(5000, true, 1000);
+
+        // Configure client with custom settings pointing to our broker
+        MqttConfig config = new MqttConfig.Builder()
+                .brokerUrl("tcp://localhost:" + brokerPort)
+                .protocolVersion(3) // MQTT 3.1.1 supported by Moquette
+                .clientId("restheart-reconnect-test")
+                .cleanSession(true)
+                .connectTimeoutSeconds(10)
+                .reconnectConfig(new MqttConfig.ReconnectConfig(true, 100L, 1000L))
+                .willConfig(new MqttConfig.WillConfig(null, null, 0, false, 0, null))
+                .build();
+
+        MqttClientSingleton.init(config);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Disconnect and clean up
+        try {
+            MqttClient client = MqttClientSingleton.getInstance().getClient();
+            if (client instanceof Mqtt3AsyncClient) {
+                ((Mqtt3AsyncClient) client).disconnect();
+            }
+        } catch (Exception e) {
+            // Ignore
+        }
+        resetSingletons();
+    }
+
+    private void resetSingletons() {
+        try {
+            // Reset MqttClientSingleton
+            Field initializedField = MqttClientSingleton.class.getDeclaredField("initialized");
+            initializedField.setAccessible(true);
+            initializedField.setBoolean(null, false);
+
+            MqttClientSingleton clientInstance = (MqttClientSingleton) System.getProperties().get(MqttClientSingleton.class.getName());
+            if (clientInstance != null) {
+                Field clientField = MqttClientSingleton.class.getDeclaredField("mqttClient");
+                clientField.setAccessible(true);
+                clientField.set(clientInstance, null);
+
+                Field connectedField = MqttClientSingleton.class.getDeclaredField("connected");
+                connectedField.setAccessible(true);
+                connectedField.set(clientInstance, false);
+            }
+
+            // Reset MqttMessageRouter
+            MqttMessageRouter routerInstance = (MqttMessageRouter) System.getProperties().get(MqttMessageRouter.class.getName());
+            if (routerInstance != null) {
+                Field routerInitializedField = MqttMessageRouter.class.getDeclaredField("initialized");
+                routerInitializedField.setAccessible(true);
+                ((AtomicBoolean) routerInitializedField.get(routerInstance)).set(false);
+
+                Field listenersField = MqttMessageRouter.class.getDeclaredField("listeners");
+                listenersField.setAccessible(true);
+                ((java.util.Map<?, ?>) listenersField.get(routerInstance)).clear();
+
+                Field cacheField = MqttMessageRouter.class.getDeclaredField("lastMessageCache");
+                cacheField.setAccessible(true);
+                ((java.util.Map<?, ?>) cacheField.get(routerInstance)).clear();
+            }
+        } catch (Exception e) {
+            // Ignore
+        }
+    }
+
+    @Test
+    void testMqttReconnectResubscribe() throws Exception {
+        // Verify we can connect and subscribe
+        MqttClient client = MqttClientSingleton.getInstance().getClient();
+        assertEquals(MqttClientState.CONNECTED, client.getState());
+
+        LinkedBlockingQueue<MqttMessage> receivedMessages = new LinkedBlockingQueue<>();
+        router.subscribe("sensors/#", MqttQos.AT_LEAST_ONCE, receivedMessages::add);
+
+        // Wait for subscription to register with the broker
+        Thread.sleep(200);
+
+        // Publish message 1
+        publishMessage("sensors/temp", "payload1");
+
+        // Assert message 1 is received
+        MqttMessage msg1 = receivedMessages.poll(3, TimeUnit.SECONDS);
+        assertNotNull(msg1, "Failed to receive message 1");
+        assertEquals("sensors/temp", msg1.getTopic());
+        assertEquals("payload1", msg1.getPayload());
+
+        // Stop the embedded broker
+        server.stopServer();
+        
+        // Sleep to ensure client recognizes disconnection
+        Thread.sleep(500);
+
+        // Start the broker again on the same port
+        Properties restartProps = new Properties(brokerProps);
+        restartProps.setProperty(BrokerConstants.PORT_PROPERTY_NAME, String.valueOf(brokerPort));
+        server = new Server();
+        server.startServer(new MemoryConfig(restartProps));
+
+        // Wait for automatic reconnection
+        boolean reconnected = false;
+        for (int i = 0; i < 50; i++) {
+            if (MqttClientSingleton.getInstance().getClient().getState() == MqttClientState.CONNECTED) {
+                reconnected = true;
+                break;
+            }
+            Thread.sleep(100);
+        }
+        assertTrue(reconnected, "Client failed to reconnect after broker restart");
+
+        // Wait for resubscription to be processed
+        Thread.sleep(500);
+
+        // Publish message 2
+        publishMessage("sensors/temp", "payload2");
+
+        // Assert message 2 is received (meaning subscription was successfully restored)
+        MqttMessage msg2 = receivedMessages.poll(5, TimeUnit.SECONDS);
+        assertNotNull(msg2, "Failed to receive message after reconnect");
+        assertEquals("sensors/temp", msg2.getTopic());
+        assertEquals("payload2", msg2.getPayload());
+    }
+
+    private void publishMessage(String topic, String payload) {
+        MqttClient client = MqttClientSingleton.getInstance().getClient();
+        if (client instanceof Mqtt3AsyncClient) {
+            ((Mqtt3AsyncClient) client).publishWith()
+                    .topic(topic)
+                    .payload(payload.getBytes(StandardCharsets.UTF_8))
+                    .qos(MqttQos.AT_LEAST_ONCE)
+                    .send()
+                    .join();
+        }
+    }
+}


### PR DESCRIPTION
#601
1) Adds [MqttMessageRouter.java](https://github.com/SoftInstigate/restheart/compare/feat/mqtt...harshitsharma635:restheart:feat/harshit-mqtt-phase2#diff-e6a4418d68f894dc0366b024c6e2d90786152528d9df98c6a32e267cfd34a7c8) as per the requirements including re-subscribe if session is not present
2) Adds [MqttMessageRouterTest.java](https://github.com/SoftInstigate/restheart/compare/feat/mqtt...harshitsharma635:restheart:feat/harshit-mqtt-phase2#diff-36fbc993292100b6a0841cd3a476736ffec94906342f3f54237f1b82f5e6cf8f) which has unit tests for Message router.
3) Adds [MqttReconnectIT.java](https://github.com/SoftInstigate/restheart/compare/feat/mqtt...harshitsharma635:restheart:feat/harshit-mqtt-phase2#diff-50dbb6b2a6ffb3373df3844bfc14e6ebf069c3d5bb7fba794ddbbf31c85f4669) for reconnect integration test embedded moquette broker.
4) Adds [MqttMessage.java](https://github.com/SoftInstigate/restheart/compare/feat/mqtt...harshitsharma635:restheart:feat/harshit-mqtt-phase2#diff-ebef3de1cd07d6b5beafdefd4ac603bf84921a05be4dbbfee534e1992eb53902) an internal mqtt message POJO.