### PR TITLE
fix: route Truffle ops through platform thread (9.x backport, oracle/graal#7520)

### DIFF
--- a/.github/workflows/native-image-release.yml
+++ b/.github/workflows/native-image-release.yml
@@ -28,7 +28,7 @@ jobs:
             arch: windows-amd64
           - os: macos-latest
             arch: "darwin-arm64"
-    timeout-minutes: 45
+    timeout-minutes: 60
     outputs:
       ubuntu: ${{ steps.set-output.outputs.ubuntu }}
     steps:

--- a/.github/workflows/native-image-snapshot.yml
+++ b/.github/workflows/native-image-snapshot.yml
@@ -14,7 +14,7 @@ jobs:
             arch: windows-amd64
           - os: macos-latest
             arch: "darwin-arm64"
-    timeout-minutes: 45
+    timeout-minutes: 60
     outputs:
       ubuntu: ${{ steps.set-output.outputs.ubuntu }}
     steps:

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -23,7 +23,9 @@ COPY target/plugins/lib/*.jar plugins/lib/
 ENV RHO='/mclient/connection-string->"mongodb://host.docker.internal";/http-listener/host->"0.0.0.0"'
 
 # JDK 25 optimized for RESTHeart: low-latency REST API, 1-2 vCPU, 1-2GB container RAM
-# ZGC (generational) for predictable pause times with Virtual Threads and short-lived request objects
+# Default G1 GC is the best fit: MongoDB is the bottleneck, not the JVM.
+# ZGC would add CPU and memory overhead with no benefit when virtual threads
+# are mostly parked on I/O. G1 pause times are short enough at 1-2GB heaps.
 # NOTE: Graal JIT is enabled by default to support GraalVM polyglot plugin capabilities.
 # If you are not using polyglot plugins, adding -XX:-UseJVMCICompiler will reduce
 # compiler memory overhead significantly in constrained containers (recommended for <512Mi heap).
@@ -31,10 +33,8 @@ ENTRYPOINT [ "java", \
     "-Dfile.encoding=UTF-8", \
     "--enable-native-access=ALL-UNNAMED", \
     "--sun-misc-unsafe-memory-access=allow", \
-    "-XX:+UseZGC", \
-    "-XX:+ZGenerational", \
     "-XX:MaxRAMPercentage=70.0", \
-    "-XX:InitialRAMPercentage=25.0", \
+    "-XX:InitialRAMPercentage=60.0", \
     "-XX:+DisableExplicitGC", \
     "-XX:+ExitOnOutOfMemoryError", \
     "-XX:+UseCompactObjectHeaders", \

--- a/polyglot/pom.xml
+++ b/polyglot/pom.xml
@@ -46,6 +46,11 @@
         <groupId>org.graalvm.js</groupId>
         <artifactId>js-language</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/polyglot/src/main/java/org/restheart/polyglot/ContextQueue.java
+++ b/polyglot/src/main/java/org/restheart/polyglot/ContextQueue.java
@@ -82,9 +82,38 @@ public class ContextQueue {
         this.modulesReplacements = modulesReplacements;
         this.OPTS = OPTS;
 
-        // Pre-populate pool
+        // Pre-populate pool on the dedicated platform thread.  Each Context
+        // is created, entered, bound, left and returned to the pool — all on
+        // the same thread that will be used at runtime, to avoid
+        // DefaultContextThreadLocal index corruption (oracle/graal#7520).
+        //
+        // If already on the platform thread (e.g. called from within a
+        // JSInterceptorFactory.create lambda), create directly to avoid
+        // self-deadlock on the single-threaded executor.
+        if (PolyglotThreadUtils.isAlreadyOnPlatformThread()) {
+            populatePool(engine, name, conf, logger, mclient, modulesReplacements);
+        } else {
+            try {
+                PolyglotThreadUtils.onPlatformThread(() -> {
+                    populatePool(engine, name, conf, logger, mclient, modulesReplacements);
+                    return null;
+                });
+            } catch (Exception e) {
+                throw new IllegalStateException("Error pre-populating polyglot context pool", e);
+            }
+        }
+    }
+
+    private void populatePool(Engine engine, String name, Configuration conf, Logger logger, Optional<MongoClient> mclient, String modulesReplacements) {
         for (var c = 0;c < POOL_SIZE;c++) {
-            pool.offer(newContext());
+            var ctx = newContext(engine, name, conf, logger, mclient, modulesReplacements, OPTS);
+            ctx.enter();
+            try {
+                addBindings(ctx, name, conf, logger, mclient);
+            } finally {
+                ctx.leave();
+            }
+            pool.offer(ctx);
         }
     }
 
@@ -110,9 +139,16 @@ public class ContextQueue {
      */
     private void release(Context ctx) {
         if (!pool.offer(ctx)) {
-            // Pool is full, close the context
-            ctx.close();
-            LOGGER.debug("Pool full, closed excess context");
+            try {
+                // Context.close() touches thread locals, must run on a platform thread, see PolyglotThreadUtils
+                PolyglotThreadUtils.onPlatformThread(() -> {
+                    ctx.close();
+                    return null;
+                });
+                LOGGER.debug("Pool full, closed excess context");
+            } catch (Exception e) {
+                LOGGER.warn("Error closing excess context", e);
+            }
         }
     }
 
@@ -127,14 +163,23 @@ public class ContextQueue {
      * @throws Exception if the task throws an exception
      */
     public <T> T executeWithContext(ContextTask<T> task) throws Exception {
-        Context ctx = acquire();
-        ctx.enter();
-        try {
-            return task.run(ctx);
-        } finally {
-            ctx.leave();
-            release(ctx);
-        }
+        // acquire/enter/task/leave/release must all happen on the very same
+        // platform thread: if the pool is empty, acquire() calls newContext()
+        // which creates a Context that must be entered on the same thread
+        // (see PolyglotThreadUtils / oracle/graal#7520).
+        return PolyglotThreadUtils.onPlatformThread(() -> {
+            Context ctx = acquire();
+            try {
+                ctx.enter();
+                try {
+                    return task.run(ctx);
+                } finally {
+                    ctx.leave();
+                }
+            } finally {
+                release(ctx);
+            }
+        });
     }
 
     /**
@@ -144,14 +189,20 @@ public class ContextQueue {
      * @throws Exception if the task throws an exception
      */
     public void executeWithContext(VoidContextTask task) throws Exception {
-        Context ctx = acquire();
-        ctx.enter();
-        try {
-            task.run(ctx);
-        } finally {
-            ctx.leave();
-            release(ctx);
-        }
+        PolyglotThreadUtils.onPlatformThread(() -> {
+            Context ctx = acquire();
+            try {
+                ctx.enter();
+                try {
+                    task.run(ctx);
+                } finally {
+                    ctx.leave();
+                }
+            } finally {
+                release(ctx);
+            }
+            return null;
+        });
     }
 
     /**
@@ -213,11 +264,9 @@ public class ContextQueue {
     }
 
     public static Context newContext(Engine engine, String name, Configuration conf, Logger logger, Optional<MongoClient> mclient, String modulesReplacements, Map<String, String> OPTS) {
+        // js.commonjs-core-modules-replacements was removed in GraalVM 25.1.x
         if (modulesReplacements != null) {
-            LOGGER.trace("modules-replacements: {} ", modulesReplacements);
-            OPTS.put("js.commonjs-core-modules-replacements", modulesReplacements);
-        } else {
-            OPTS.remove("js.commonjs-core-modules-replacements");
+            LOGGER.trace("modules-replacements ignored (removed in GraalVM 25.1): {}", modulesReplacements);
         }
 
         var ctx = Context.newBuilder().engine(engine)
@@ -230,12 +279,18 @@ public class ContextQueue {
                 .options(OPTS)
                 .build();
 
-        addBindings(ctx, name, conf, logger, mclient);
-
+        // NOTE: addBindings() is NOT called here.  It requires ctx.enter(),
+        // and a second enter()/leave() cycle before the caller's own
+        // enter() corrupts Truffle's DefaultContextThreadLocal (oracle/graal#7520).
+        // Callers must call addBindings() AFTER entering the context.
         return ctx;
     }
 
-    private static void addBindings(Context ctx,
+    /**
+     * Adds default bindings (LOGGER, mclient, pluginArgs) to an already-entered
+     * context.  Must only be called between ctx.enter() and ctx.leave().
+     */
+    public static void addBindings(Context ctx,
                                     String pluginName,
                                     Configuration conf,
                                     Logger logger,

--- a/polyglot/src/main/java/org/restheart/polyglot/JSPlugin.java
+++ b/polyglot/src/main/java/org/restheart/polyglot/JSPlugin.java
@@ -35,7 +35,34 @@ import com.mongodb.client.MongoClient;
 public abstract class JSPlugin {
     protected static final Logger LOGGER = LoggerFactory.getLogger(JSPlugin.class);
 
-    private static final Engine engine = Engine.create();
+    private static volatile Engine engine;
+
+    /**
+     * Returns the shared polyglot Engine, creating it on the dedicated
+     * platform thread on first access.  Lazy initialization avoids the
+     * deadlock that would occur if we created the Engine in a static
+     * initializer (the main thread holds the class-init lock while
+     * waiting for the platform thread).
+     */
+    public static Engine engine() {
+        if (engine == null) {
+            synchronized (JSPlugin.class) {
+                if (engine == null) {
+                    try {
+                        if (PolyglotThreadUtils.isAlreadyOnPlatformThread()) {
+                            engine = PolyglotClassloaderHelper.withPluginsClassloaderResult(Engine::create);
+                        } else {
+                            engine = PolyglotThreadUtils.onPlatformThread(
+                                () -> PolyglotClassloaderHelper.withPluginsClassloaderResult(Engine::create));
+                        }
+                    } catch (Exception e) {
+                        throw new IllegalStateException("Error creating polyglot Engine", e);
+                    }
+                }
+            }
+        }
+        return engine;
+    }
 
     private final String modulesReplacements;
     private final Source handleSource;
@@ -116,7 +143,4 @@ public abstract class JSPlugin {
         return configuration;
     }
 
-    public static Engine engine() {
-        return engine;
-    }
 }

--- a/polyglot/src/main/java/org/restheart/polyglot/PolyglotClassloaderHelper.java
+++ b/polyglot/src/main/java/org/restheart/polyglot/PolyglotClassloaderHelper.java
@@ -1,0 +1,120 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-polyglot
+ * %%
+ * Copyright (C) 2018 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+package org.restheart.polyglot;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility to set the thread context classloader to the PluginsClassloader
+ * before calling GraalVM's Source.findLanguage().
+ *
+ * <p>Source.findLanguage() discovers languages via ServiceLoader using the
+ * thread context classloader. The js-language JAR lives in plugins/lib/,
+ * which is only visible to the PluginsClassloader, not the system classloader.</p>
+ */
+public final class PolyglotClassloaderHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PolyglotClassloaderHelper.class);
+
+    private static final String PCL_CLASS = "org.restheart.plugins.PluginsClassloader";
+
+    /**
+     * Functional interface that allows IOException to be thrown.
+     */
+    @FunctionalInterface
+    public interface IORunnable {
+        void run() throws IOException;
+    }
+
+    /**
+     * Functional interface that returns a value and allows IOException.
+     */
+    @FunctionalInterface
+    public interface IOCallable<T> {
+        T call() throws IOException;
+    }
+
+    private PolyglotClassloaderHelper() {}
+
+    /**
+     * Returns the PluginsClassloader instance via reflection, or null if
+     * unavailable.
+     */
+    public static ClassLoader getPluginsClassloader() {
+        try {
+            Class<?> pclClass = Class.forName(PCL_CLASS);
+            var getInstance = pclClass.getMethod("getInstance");
+            return (ClassLoader) getInstance.invoke(null);
+        } catch (Exception e) {
+            LOGGER.debug("PluginsClassloader not available via reflection", e);
+            return null;
+        }
+    }
+
+    /**
+     * Sets the thread context classloader to the PluginsClassloader for the
+     * duration of the action, then restores the original.
+     *
+     * @param action code to run with the PluginsClassloader as context classloader
+     * @throws IOException if the action throws an IOException
+     */
+    public static void withPluginsClassloader(IORunnable action) throws IOException {
+        ClassLoader pluginsCl = getPluginsClassloader();
+        if (pluginsCl == null) {
+            action.run();
+            return;
+        }
+
+        ClassLoader oldCl = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(pluginsCl);
+        try {
+            action.run();
+        } finally {
+            Thread.currentThread().setContextClassLoader(oldCl);
+        }
+    }
+
+    /**
+     * Sets the thread context classloader to the PluginsClassloader for the
+     * duration of the callable, then restores the original. Returns the result.
+     *
+     * @param callable code to run with the PluginsClassloader as context classloader
+     * @return the result of the callable
+     * @throws IOException if the callable throws an IOException
+     */
+    public static <T> T withPluginsClassloaderResult(IOCallable<T> callable) throws IOException {
+        ClassLoader pluginsCl = getPluginsClassloader();
+        if (pluginsCl == null) {
+            return callable.call();
+        }
+
+        ClassLoader oldCl = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(pluginsCl);
+        try {
+            return callable.call();
+        } finally {
+            Thread.currentThread().setContextClassLoader(oldCl);
+        }
+    }
+}

--- a/polyglot/src/main/java/org/restheart/polyglot/PolyglotDeployer.java
+++ b/polyglot/src/main/java/org/restheart/polyglot/PolyglotDeployer.java
@@ -78,9 +78,9 @@ import com.mongodb.client.MongoClient;
  * @author Andrea Di Cesare {@literal <andrea@softinstigate.com>}
  */
 @RegisterPlugin(
-        name = "polyglotDeployer",
-        description = "handles GraalVM polyglot plugins",
-        enabledByDefault = true)
+    name = "polyglotDeployer",
+    description = "handles GraalVM polyglot plugins",
+    enabledByDefault = true)
 public class PolyglotDeployer implements Initializer {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PolyglotDeployer.class);
@@ -352,16 +352,12 @@ public class PolyglotDeployer implements Initializer {
 
                         if (checkPluginFiles) {
                             if (Files.isRegularFile(pluginPath)) {
-                                try {
-                                    final var language = Source.findLanguage(pluginPath.toFile());
-                                    if ("js".equals(language)) {
-                                        ret.add(pluginPath);
-                                    } else {
-                                        LOGGER.warn("{} is not javascript", pluginPath.toAbsolutePath());
-                                    }
-                                } catch (final IOException e) {
-                                    LOGGER.warn("{} is not javascript", pluginPath.toAbsolutePath(), e);
-                                }
+                                // Source.findLanguage() is NOT called here:
+                                // it triggers Truffle's language-discovery
+                                // internals which corrupt DefaultContextThread-
+                                // Local (oracle/graal#7520).  Files are
+                                // already filtered to .mjs by the deployer.
+                                ret.add(pluginPath);
                             } else {
                                 LOGGER.warn("pluging not found {}, it is declared in {}", pluginPath.toAbsolutePath(),
                                         packagePath.toAbsolutePath());
@@ -453,8 +449,8 @@ public class PolyglotDeployer implements Initializer {
                 DEPLOYEES.put(pluginPath.toAbsolutePath(), srv);
 
                 LOGGER.info(ansi().fg(GREEN).a(
-                                "Service '{}' deployed at URI '{}' with description: '{}'. Secured: {}. Uri match policy: {}")
-                                .reset().toString(), srv.name(), srv.uri(), srv.getDescription(), srv.secured(),
+                        "Service '{}' deployed at URI '{}' with description: '{}'. Secured: {}. Uri match policy: {}")
+                        .reset().toString(), srv.name(), srv.uri(), srv.getDescription(), srv.secured(),
                         srv.matchPolicy());
             } catch (IOException | InterruptedException | ExecutionException | TimeoutException ex) {
                 LOGGER.error("Error deploying node service {}", pluginPath, ex);

--- a/polyglot/src/main/java/org/restheart/polyglot/PolyglotThreadUtils.java
+++ b/polyglot/src/main/java/org/restheart/polyglot/PolyglotThreadUtils.java
@@ -1,0 +1,174 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-polyglot
+ * %%
+ * Copyright (C) 2020 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+package org.restheart.polyglot;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.graalvm.polyglot.Engine;
+
+/**
+ * Runs GraalVM polyglot Context creation, enter/leave and eval on a dedicated
+ * single platform thread.
+ *
+ * <p>Truffle's {@code DefaultContextThreadLocal} (see oracle/graal#7520) stores
+ * per-thread state in a fixed-size slot array indexed by an internal counter.
+ * When Engine and Context objects are created on one thread and then used from
+ * a different thread, the slot indices can resolve to {@code -1}, causing an
+ * {@code ArrayIndexOutOfBoundsException}. Using a <em>single</em> dedicated
+ * thread for <strong>all</strong> polyglot operations eliminates the
+ * cross-thread access entirely.</p>
+ *
+ * <p>When the Truffle bug is fixed, set the system property
+ * {@code restheart.polyglot.force-platform-threads=false} to let polyglot
+ * operations run on the caller thread (virtual or platform) directly,
+ * bypassing the dedicated thread entirely.</p>
+ */
+public final class PolyglotThreadUtils {
+    /**
+     * System property to control whether polyglot operations are forced onto
+     * a dedicated platform thread. Defaults to {@code true} (workaround for
+     * oracle/graal#7520). Set to {@code false} once Truffle fully supports
+     * virtual threads.
+     */
+    private static final String FORCE_PLATFORM_PROP = "restheart.polyglot.force-platform-threads";
+
+    private static final boolean FORCE_PLATFORM;
+
+    static {
+        FORCE_PLATFORM = Boolean.parseBoolean(
+                System.getProperty(FORCE_PLATFORM_PROP, "true"));
+    }
+
+    // Single dedicated platform thread for ALL Truffle operations.
+    // Using one thread avoids DefaultContextThreadLocal cross-thread corruption
+    // (see oracle/graal#7520).  The unbounded queue serialises polyglot work;
+    // under extreme concurrency this adds latency but never crashes.
+    private static volatile ExecutorService platformExecutor;
+
+    private static ExecutorService getPlatformExecutor() {
+        if (platformExecutor == null) {
+            synchronized (PolyglotThreadUtils.class) {
+                if (platformExecutor == null) {
+                    platformExecutor = Executors.newSingleThreadExecutor(runnable -> {
+                        return Thread.ofPlatform().name("RH JS PLT", 0).unstarted(() -> {
+                            // Set PluginsClassloader on the platform thread so that ALL
+                            // Truffle operations use the same classloader context.
+                            var pluginsCl = PolyglotClassloaderHelper.getPluginsClassloader();
+                            if (pluginsCl != null) {
+                                Thread.currentThread().setContextClassLoader(pluginsCl);
+                            }
+                            runnable.run();
+                        });
+                    });
+                }
+            }
+        }
+        return platformExecutor;
+    }
+
+    private PolyglotThreadUtils() {}
+
+    /**
+     * Creates a polyglot Engine with the PluginsClassloader as context classloader.
+     *
+     * <p>Declared here (not as a lambda body inside JSPlugin's static initializer)
+     * so that invoking it from a platform thread never needs to wait on JSPlugin's
+     * own class-initialization monitor, which would deadlock since JSPlugin's
+     * &lt;clinit&gt; is the one submitting this task and blocking on its result.</p>
+     *
+     * @return a newly created Engine
+     */
+    public static Engine createEngine() throws IOException {
+        return PolyglotClassloaderHelper.withPluginsClassloaderResult(Engine::create);
+    }
+
+    /**
+     * Runs the given task on the dedicated platform thread and waits for its result.
+     *
+     * <p>When {@code restheart.polyglot.force-platform-threads} is {@code true}
+     * (the default), the task is dispatched to the single dedicated platform
+     * thread. When set to {@code false}, the task runs directly on the caller
+     * thread.</p>
+     *
+     * @param task the task to run
+     * @return the result of the task
+     * @throws Exception if the task throws an exception
+     */
+    public static <T> T onPlatformThread(Callable<T> task) throws Exception {
+        if (!FORCE_PLATFORM) {
+            return task.call();
+        }
+
+        try {
+            return getPlatformExecutor().submit(task).get();
+        } catch (ExecutionException e) {
+            var cause = e.getCause();
+            if (cause instanceof Exception ex) {
+                throw ex;
+            } else if (cause instanceof Error err) {
+                throw err;
+            } else {
+                throw e;
+            }
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw ie;
+        }
+    }
+
+    /**
+     * Returns whether polyglot operations are currently forced onto platform threads.
+     * Useful for diagnostics and tests.
+     */
+    public static boolean isForcePlatform() {
+        return FORCE_PLATFORM;
+    }
+
+    /**
+     * Returns {@code true} if the calling thread is the dedicated platform
+     * thread used by {@link #onPlatformThread(Callable)}.  Useful to avoid
+     * self-deadlock when already running inside a platform-thread lambda.
+     */
+    public static boolean isAlreadyOnPlatformThread() {
+        return FORCE_PLATFORM
+                && platformExecutor != null
+                && Thread.currentThread().getName().startsWith("RH JS PLT");
+    }
+
+    /**
+     * IOException-friendly variant of {@link #onPlatformThread(Callable)}.
+     */
+    public static <T> T onPlatformThreadIO(Callable<T> task) throws java.io.IOException, InterruptedException {
+        try {
+            return onPlatformThread(task);
+        } catch (java.io.IOException | InterruptedException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new java.io.IOException(e);
+        }
+    }
+}

--- a/polyglot/src/main/java/org/restheart/polyglot/interceptors/JSInterceptorFactory.java
+++ b/polyglot/src/main/java/org/restheart/polyglot/interceptors/JSInterceptorFactory.java
@@ -27,7 +27,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import org.graalvm.polyglot.Context;
+import org.restheart.polyglot.JSPlugin;
+import org.restheart.polyglot.PolyglotClassloaderHelper;
+import org.restheart.polyglot.PolyglotThreadUtils;
 import org.graalvm.polyglot.Engine;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
@@ -54,7 +56,7 @@ public class JSInterceptorFactory {
 
     Map<String, String> contextOptions = new HashMap<>();
 
-    private final Engine engine = Engine.create();
+    private final Engine engine;
 
     private final Optional<MongoClient> mclient;
 
@@ -63,6 +65,10 @@ public class JSInterceptorFactory {
     public JSInterceptorFactory(Optional<MongoClient> mclient, Configuration config) {
         this.mclient = mclient;
         this.config = config;
+        // Reuse the single shared Engine from JSPlugin rather than creating a
+        // second one.  Two concurrent Engines corrupt Truffle's internal
+        // DefaultContextThreadLocal bookkeeping (see oracle/graal#7520).
+        this.engine = JSPlugin.engine();
     }
 
     public PluginRecord<Interceptor<?, ?>> create(Path pluginPath) throws IOException, InterruptedException {
@@ -86,19 +92,20 @@ public class JSInterceptorFactory {
             LOGGER.debug("Enabling require for interceptor {} with require-cwd {} ", pluginPath, requireCwdPath);
         }
 
-        // check that the plugin script is js
-        var language = Source.findLanguage(pluginPath.toFile());
-
-        if (!"js".equals(language)) {
-            throw new IllegalArgumentException(
-                    "wrong js interceptor " + pluginPath.toAbsolutePath() + ", not javascript");
-        }
+        // Source.findLanguage() is NOT called here: it corrupts Truffle's
+        // DefaultContextThreadLocal (oracle/graal#7520).
+        var language = "js";
 
         // check plugin definition
         var sindexPath = pluginPath.toUri().toString();
         LOGGER.debug("Resolved interceptor path: {}", sindexPath);
 
-        try (Context ctx = ContextQueue.newContext(engine, "foo", config, LOGGER, mclient, "", contextOptions)) {
+        // All Context lifecycle must run on the dedicated platform thread.
+        try {
+        return PolyglotThreadUtils.onPlatformThreadIO(() -> {
+        var ctx = ContextQueue.newContext(engine, "foo", config, LOGGER, mclient, "", contextOptions);
+        ctx.enter();
+        try {
 
             // ******** evaluate and check options
             var optionsScript = "import { options } from '" + sindexPath + "'; options;";
@@ -233,11 +240,9 @@ public class JSInterceptorFactory {
             Map<String, String> contextOpts = Maps.newHashMap();
             contextOpts.putAll(contextOptions);
 
+            // js.commonjs-core-modules-replacements was removed in GraalVM 25.1.x
             if (modulesReplacements != null) {
-                LOGGER.trace("modules-replacements: {} ", modulesReplacements);
-                contextOpts.put("js.commonjs-core-modules-replacements", modulesReplacements);
-            } else {
-                contextOpts.remove("js.commonjs-core-modules-replacements");
+                LOGGER.trace("modules-replacements ignored (removed in GraalVM 25.1): {}", modulesReplacements);
             }
 
             switch (pluginClass) {
@@ -341,6 +346,18 @@ public class JSInterceptorFactory {
                     interceptor.getClass().getName(),
                     interceptor,
                     new HashMap<>());
+        } finally {
+            ctx.leave();
+            ctx.close();
+        }
+        });
+        } catch (Throwable t) {
+            LOGGER.error("DIAGNOSTIC: full exception chain for {} [thread={}, class={}]:",
+                    pluginPath, Thread.currentThread().getName(), t.getClass().getName(), t);
+            if (t instanceof RuntimeException re) throw re;
+            if (t instanceof IOException ioe) throw ioe;
+            if (t instanceof InterruptedException ie) { Thread.currentThread().interrupt(); throw ie; }
+            throw new IOException(t);
         }
     }
 

--- a/polyglot/src/main/java/org/restheart/polyglot/services/JSStringService.java
+++ b/polyglot/src/main/java/org/restheart/polyglot/services/JSStringService.java
@@ -26,8 +26,9 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Optional;
 
-import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Source;
+import org.restheart.polyglot.PolyglotClassloaderHelper;
+import org.restheart.polyglot.PolyglotThreadUtils;
 import org.graalvm.polyglot.Value;
 import org.restheart.configuration.Configuration;
 import org.restheart.exchange.StringRequest;
@@ -74,7 +75,7 @@ public class JSStringService extends JSService implements StringService {
         super(args(pluginPath, mclient, config));
     }
 
-    private static JSServiceArgs args(Path pluginPath, Optional<MongoClient> mclient, Configuration config) throws IOException {
+    private static JSServiceArgs args(Path pluginPath, Optional<MongoClient> mclient, Configuration config) throws IOException, InterruptedException {
         // find plugin root, i.e the parent dir that contains package.json
         var contextOptions = new HashMap<String, String>();
         var pluginRoot = pluginPath.getParent();
@@ -95,14 +96,16 @@ public class JSStringService extends JSService implements StringService {
             LOGGER.trace("Enabling require for service {} with require-cwd {} ", pluginPath, requireCwdPath);
         }
 
-        try (Context ctx = ContextQueue.newContext(engine(), "foo", config, LOGGER, mclient, "", contextOptions)) {
-            // check that the plugin script is js
-            var language = Source.findLanguage(pluginPath.toFile());
+        // All Context lifecycle must run on the dedicated platform thread.
+        // Source.findLanguage() is NOT called here: it corrupts Truffle's
+        // DefaultContextThreadLocal (oracle/graal#7520).
+        var language = "js";
 
-            if (!"js".equals(language)) {
-                throw new IllegalArgumentException("wrong js plugin, not javascript");
-            }
-
+        try {
+        return PolyglotThreadUtils.onPlatformThreadIO(() -> {
+        var ctx = ContextQueue.newContext(engine(), "foo", config, LOGGER, mclient, "", contextOptions);
+        ctx.enter();
+        try {
             var sindexPath = pluginPath.toUri().toString();
             LOGGER.debug("Resolved plugin path for import: {}", sindexPath);
             var optionsScript = "import { options } from '" + sindexPath + "'; options;";
@@ -157,6 +160,17 @@ public class JSStringService extends JSService implements StringService {
             checkHandle(handle, pluginPath);
 
             return new JSServiceArgs(name, description, uri, secured, modulesReplacements, matchPolicy, handleSource, config, mclient, contextOptions);
+        } finally {
+            ctx.leave();
+            ctx.close();
+        }
+        });
+        } catch (Throwable t) {
+            LOGGER.error("DIAGNOSTIC: full exception chain for {} [thread={}, class={}]:",
+                    pluginPath, Thread.currentThread().getName(), t.getClass().getName(), t);
+            if (t instanceof RuntimeException re) throw re;
+            if (t instanceof IOException ioe) throw ioe;
+            throw new IOException(t);
         }
     }
 

--- a/polyglot/src/main/resources/META-INF/native-image/org.restheart/restheart-polyglot/reachability-metadata.json
+++ b/polyglot/src/main/resources/META-INF/native-image/org.restheart/restheart-polyglot/reachability-metadata.json
@@ -4,10 +4,18 @@
       "type": "org.restheart.polyglot.JSPlugin",
       "fields": [
         {
+          "name": "name"
+        }
+      ]
+    },
+    {
+      "type": "org.restheart.polyglot.interceptors.JSInterceptor",
+      "fields": [
+        {
           "name": "interceptPoint"
         },
         {
-          "name": "name"
+          "name": "pluginClass"
         }
       ]
     },

--- a/polyglot/src/test/java/org/restheart/polyglot/ContextLifecycleTest.java
+++ b/polyglot/src/test/java/org/restheart/polyglot/ContextLifecycleTest.java
@@ -1,0 +1,183 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-polyglot
+ * %%
+ * Copyright (C) 2020 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+package org.restheart.polyglot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+
+import org.graalvm.polyglot.Engine;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mongodb.client.MongoClient;
+
+/**
+ * Integration tests for the full polyglot Context lifecycle on the dedicated
+ * platform thread.  These tests verify the fix for oracle/graal#7520:
+ *
+ * <ul>
+ *   <li>Contexts created on the platform thread can be entered/evaluated
+ *       without {@code ArrayIndexOutOfBoundsException} from
+ *       {@code DefaultContextThreadLocal.fastGet()}.</li>
+ *   <li>Bindings ({@code LOGGER}, {@code mclient}, {@code pluginArgs}) are
+ *       accessible inside entered contexts.</li>
+ *   <li>Contexts pooled by {@link ContextQueue} work correctly when
+ *       {@code executeWithContext()} is called from virtual threads.</li>
+ *   <li>Multiple concurrent virtual threads can use the same
+ *       {@link ContextQueue} without corruption.</li>
+ * </ul>
+ */
+class ContextLifecycleTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContextLifecycleTest.class);
+
+    private static Engine engine;
+
+    @BeforeAll
+    static void createEngine() {
+        engine = Engine.create();
+    }
+
+    @AfterAll
+    static void closeEngine() {
+        if (engine != null) {
+            engine.close();
+        }
+    }
+
+    @Test
+    void newContextReturnsBareContext() {
+        var ctx = ContextQueue.newContext(engine, "test", null, LOGGER,
+                Optional.<MongoClient>empty(), null, Map.of());
+        assertNotNull(ctx);
+        ctx.enter();
+        try {
+            var result = ctx.eval("js", "1+1").asInt();
+            assertEquals(2, result);
+        } finally {
+            ctx.leave();
+            ctx.close();
+        }
+    }
+
+    @Test
+    void addBindingsMakesValuesAccessibleFromJS() {
+        var ctx = ContextQueue.newContext(engine, "test", null, LOGGER,
+                Optional.<MongoClient>empty(), null, Map.of());
+        ctx.enter();
+        try {
+            ContextQueue.addBindings(ctx, "test", null, LOGGER,
+                    Optional.<MongoClient>empty());
+
+            var hasLogger = ctx.eval("js", "typeof LOGGER !== 'undefined'").asBoolean();
+            assertTrue(hasLogger, "LOGGER binding should be accessible");
+
+            var hasArgs = ctx.eval("js", "typeof pluginArgs !== 'undefined'").asBoolean();
+            assertTrue(hasArgs, "pluginArgs binding should be accessible");
+        } finally {
+            ctx.leave();
+            ctx.close();
+        }
+    }
+
+    @Test
+    void pooledContextWorksFromVirtualThread() throws Exception {
+        var cq = new ContextQueue(engine, "test-pool", null, LOGGER,
+                Optional.<MongoClient>empty(), null, Map.of());
+
+        var result = new AtomicReference<Object>();
+        var failure = new AtomicReference<Throwable>();
+
+        var vt = Thread.ofVirtual().unstarted(() -> {
+            try {
+                result.set(cq.executeWithContext((ContextQueue.ContextTask<Integer>) ctx ->
+                        ctx.eval("js", "21*2").asInt()));
+            } catch (Throwable t) {
+                failure.set(t);
+            }
+        });
+        vt.start();
+        vt.join();
+
+        assertNull(failure.get(), () -> "virtual thread failed: " + failure.get());
+        assertEquals(42, result.get());
+    }
+
+    @Test
+    void concurrentVirtualThreadsUseSameContextQueue() throws Exception {
+        var cq = new ContextQueue(engine, "test-concurrent", null, LOGGER,
+                Optional.<MongoClient>empty(), null, Map.of());
+
+        var failures = new AtomicReference<String>();
+
+        var threads = IntStream.range(0, 20)
+                .mapToObj(i -> Thread.ofVirtual().unstarted(() -> {
+                    try {
+                        var expected = i * i;
+                        var actual = cq.executeWithContext((ContextQueue.ContextTask<Integer>) ctx ->
+                                ctx.eval("js", i + "*" + i).asInt());
+                        if (actual != expected) {
+                            failures.compareAndSet(null,
+                                    "expected " + expected + " but got " + actual);
+                        }
+                    } catch (Throwable t) {
+                        failures.compareAndSet(null,
+                                "thread " + i + " failed: " + t.getMessage());
+                    }
+                }))
+                .toList();
+
+        for (var t : threads) t.start();
+        for (var t : threads) t.join();
+
+        assertNull(failures.get(), failures::get);
+    }
+
+    @Test
+    void engineCreatedByOnPlatformThreadWorksForContextOps() throws Exception {
+        var pltEngine = PolyglotThreadUtils.onPlatformThread(Engine::create);
+        assertNotNull(pltEngine);
+
+        try {
+            var ctx = ContextQueue.newContext(pltEngine, "test", null, LOGGER,
+                    Optional.<MongoClient>empty(), null, Map.of());
+            ctx.enter();
+            try {
+                var result = ctx.eval("js", "'hello' + ' world'").asString();
+                assertEquals("hello world", result);
+            } finally {
+                ctx.leave();
+                ctx.close();
+            }
+        } finally {
+            pltEngine.close();
+        }
+    }
+}

--- a/polyglot/src/test/java/org/restheart/polyglot/PolyglotThreadUtilsExtendedTest.java
+++ b/polyglot/src/test/java/org/restheart/polyglot/PolyglotThreadUtilsExtendedTest.java
@@ -1,0 +1,117 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-polyglot
+ * %%
+ * Copyright (C) 2020 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+package org.restheart.polyglot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link PolyglotThreadUtils} covering
+ * {@code isAlreadyOnPlatformThread()} and {@code onPlatformThreadIO()}.
+ */
+class PolyglotThreadUtilsExtendedTest {
+
+    @Test
+    void isAlreadyOnPlatformThreadReturnsFalseOnMainThread() {
+        assertFalse(PolyglotThreadUtils.isAlreadyOnPlatformThread(),
+                "main thread is not the platform executor thread");
+    }
+
+    @Test
+    void isAlreadyOnPlatformThreadReturnsTrueInsideOnPlatformThread() throws Exception {
+        var result = PolyglotThreadUtils.onPlatformThread(
+                () -> PolyglotThreadUtils.isAlreadyOnPlatformThread());
+        assertTrue(result,
+                "task running inside onPlatformThread should see itself as on the platform thread");
+    }
+
+    @Test
+    void isAlreadyOnPlatformThreadReturnsFalseOnOtherPlatformThread() throws Exception {
+        var result = new AtomicBoolean(true);
+        var t = new Thread(() ->
+                result.set(PolyglotThreadUtils.isAlreadyOnPlatformThread()));
+        t.start();
+        t.join();
+        assertFalse(result.get(),
+                "a different platform thread is not the RH JS PLT thread");
+    }
+
+    @Test
+    void isAlreadyOnPlatformThreadReturnsFalseOnVirtualThread() throws Exception {
+        var result = new AtomicBoolean(true);
+        var failure = new AtomicReference<Throwable>();
+
+        var vt = Thread.ofVirtual().unstarted(() -> {
+            try {
+                result.set(PolyglotThreadUtils.isAlreadyOnPlatformThread());
+            } catch (Throwable t) {
+                failure.set(t);
+            }
+        });
+        vt.start();
+        vt.join();
+
+        assertNull(failure.get(), () -> String.valueOf(failure.get()));
+        assertFalse(result.get(),
+                "a virtual thread is not the RH JS PLT thread");
+    }
+
+    @Test
+    void onPlatformThreadIOReturnsValue() throws Exception {
+        var result = PolyglotThreadUtils.onPlatformThreadIO(() -> 42);
+        assertEquals(42, result);
+    }
+
+    @Test
+    void onPlatformThreadIOPropagatesIOException() {
+        var ex = assertThrows(IOException.class,
+                () -> PolyglotThreadUtils.onPlatformThreadIO(() -> {
+                    throw new IOException("io-boom");
+                }));
+        assertEquals("io-boom", ex.getMessage());
+    }
+
+    @Test
+    void onPlatformThreadIOPropagatesRuntimeException() {
+        var ex = assertThrows(IllegalStateException.class,
+                () -> PolyglotThreadUtils.onPlatformThreadIO(() -> {
+                    throw new IllegalStateException("rt-boom");
+                }));
+        assertEquals("rt-boom", ex.getMessage());
+    }
+
+    @Test
+    void onPlatformThreadIORunsOnPlatformThread() throws Exception {
+        var threadName = PolyglotThreadUtils.onPlatformThreadIO(
+                () -> Thread.currentThread().getName());
+        assertTrue(threadName.startsWith("RH JS PLT"),
+                "onPlatformThreadIO should dispatch to the platform thread");
+    }
+}


### PR DESCRIPTION
## Summary

Backport of the polyglot fix from master to the 9.x branch. Fixes `ArrayIndexOutOfBoundsException: Index -1 out of bounds for length 10` in Truffle's `DefaultContextThreadLocal.fastGet()` when Java 25 virtual threads interact with GraalVM 25.x polyglot contexts.

**Closes #663** (for the 9.x line)

## Problem

GraalVM Truffle 25.x does not support Java virtual threads (oracle/graal#7520). RESTHeart uses virtual threads for request handling and plugin deployment. Any code path that creates/enters/evaluates a GraalVM Context on a virtual thread hits the `ArrayIndexOutOfBoundsException`.

## Solution

Route all Truffle operations through a single dedicated platform thread (`"RH JS PLT"`):

| File | Change |
|---|---|
| `PolyglotThreadUtils.java` | New: single platform thread executor with PluginsClassloader, `isAlreadyOnPlatformThread()`, `onPlatformThreadIO()` |
| `PolyglotClassloaderHelper.java` | New: `getPluginsClassloader()` made public |
| `JSPlugin.java` | Lazy Engine creation on platform thread (avoids clinit deadlock) |
| `ContextQueue.java` | Pool pre-population on platform thread, `addBindings()` public, `populatePool()` helper with deadlock guard |
| `PolyglotDeployer.java` | Removed `Source.findLanguage()` (corrupts DefaultContextThreadLocal) |
| `JSStringService.java` | Wrapped startup Context lifecycle in `onPlatformThreadIO` |
| `JSInterceptorFactory.java` | Same as JSStringService |
| `reachability-metadata.json` | Fixed `interceptPoint` field: `JSInterceptor` instead of `JSPlugin` |
| `polyglot/pom.xml` | Added `junit-jupiter` test dependency |

## Testing

- 13 polyglot tests pass (8 new + 5 existing)
- Docker e2e: 6 services + 3 interceptors deploy, `curl /hello` returns interceptor-modified response
- Published as `softinstigate/restheart-snapshot:diagnostic`

## Escape hatch

```bash
-Drestheart.polyglot.force-platform-threads=false
```

Bypasses the platform thread dispatch when oracle/graal#7520 is fixed upstream (tracked in #665).

## Preserved commits

- `16a285ae6` — increase timeout to 60 minutes in native image workflows
- `b34134e36` — update Dockerfile optimize JVM options for better performance