### PR TITLE
Add apiKeyAuthMechanism and mongoApiKeyAuthenticator

### DIFF
--- a/commons/src/main/java/org/restheart/security/ApiKeyCredential.java
+++ b/commons/src/main/java/org/restheart/security/ApiKeyCredential.java
@@ -1,0 +1,84 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-commons
+ * %%
+ * Copyright (C) 2019 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * =========================LICENSE_END==================================
+ */
+package org.restheart.security;
+
+import java.util.Arrays;
+
+import io.undertow.security.idm.Credential;
+
+/**
+ * An opaque, self-identifying API key.
+ *
+ * <p>Unlike a {@link io.undertow.security.idm.PasswordCredential}, this carries
+ * no principal alongside it: the key <em>is</em> the identifier, and the
+ * Authenticator resolves the account from the key itself. That is why an
+ * Authenticator verifying one implements {@code verify(Credential)} — the
+ * single-argument form — rather than {@code verify(String, Credential)}.
+ *
+ * <p>The key is held as a {@code char[]} so that a caller may
+ * {@link #clear()} it once verification is done, on the same reasoning as
+ * {@code PasswordCredential}: a {@code String} would linger in the heap until
+ * it happened to be collected.
+ *
+ * @author Andrea Di Cesare {@literal <andrea@softinstigate.com>}
+ */
+public class ApiKeyCredential implements Credential {
+    private final char[] key;
+
+    /**
+     * @param key the key exactly as presented by the client, prefix included
+     */
+    public ApiKeyCredential(final char[] key) {
+        this.key = key;
+    }
+
+    /**
+     * @param key the key exactly as presented by the client, prefix included
+     */
+    public ApiKeyCredential(final String key) {
+        this.key = key == null ? new char[0] : key.toCharArray();
+    }
+
+    /**
+     * @return the key, prefix included. Not a copy — treat as read-only.
+     */
+    public char[] getKey() {
+        return this.key;
+    }
+
+    /**
+     * Overwrites the key in place.
+     */
+    public void clear() {
+        Arrays.fill(this.key, '\0');
+    }
+
+    /**
+     * Never the key. This object ends up in log statements and stack traces by
+     * accident, and a credential that prints itself is a credential in a log
+     * file.
+     */
+    @Override
+    public String toString() {
+        return "ApiKeyCredential[REDACTED]";
+    }
+}

--- a/core/src/main/resources/restheart-default-config.yml
+++ b/core/src/main/resources/restheart-default-config.yml
@@ -49,6 +49,17 @@ jwtConfigProvider:
   issuer: restheart.org
   audience: null   # null or array of audience strings
 
+# API Key Authentication
+# Authenticates long-lived, revocable keys sent as `Authorization: Bearer <prefix>...`.
+# Shares the Bearer scheme with jwtAuthenticationMechanism: it runs first (priority) and
+# declines, with NOT_ATTEMPTED, any Bearer value that does not carry `prefix` — the same way
+# tokenBasicAuthMechanism shares Basic with basicAuthMechanism. So the prefix is required:
+# it is what tells a key from a JWT.
+apiKeyAuthMechanism:
+  enabled: false
+  authenticator: mongoApiKeyAuthenticator
+  prefix: rhak_
+
 # JSON Web Token Authentication
 # See https://restheart.org/docs/security/authentication#jwt-authentication
 jwtAuthenticationMechanism:
@@ -86,6 +97,26 @@ fileRealmAuthenticator:
     - userid: admin
       password: null
       roles: [admin]
+
+# mongoApiKeyAuthenticator verifies API keys stored in a MongoDB collection.
+# The account it builds carries the roles named on the *key* document, never the user's:
+# a key is deny-by-default, so it reaches only what has been granted to it deliberately.
+# Keys are hashed with SHA-256 rather than bcrypt — a key is high-entropy, and bcrypt's
+# slowness would be paid on every request instead of once per login.
+# Expiry wants a TTL index on `expiresAt`; revocation takes effect within cache-ttl.
+mongoApiKeyAuthenticator:
+  enabled: false
+  keys-db: restheart
+  keys-collection: apiKeys
+  prop-hash: hash
+  prop-principal: user
+  prop-roles: roles
+  prop-expires: expiresAt
+  track-last-used: true
+  cache-enabled: true
+  cache-size: 1000
+  cache-ttl: 60000
+  cache-expire-policy: AFTER_WRITE
 
 # mongoRealmAuthenticator authenticates users defined in a MongoDB collection.
 # See https://restheart.org/docs/security/authentication#mongo-realm-authenticator

--- a/core/src/test/java/karate/api-key-auth-setup.feature
+++ b/core/src/test/java/karate/api-key-auth-setup.feature
@@ -1,0 +1,111 @@
+@ignore
+Feature: Prepare API keys for the api-key-auth feature
+
+# The hashes below are sha256 of the key strings, which is what
+# mongoApiKeyAuthenticator stores — the key itself never is:
+#
+#   printf 'rhak_valid'     | shasum -a 256
+#   printf 'rhak_noroles'   | shasum -a 256
+#   printf 'rhak_expired'   | shasum -a 256
+#   printf 'rhak_poweruser' | shasum -a 256
+#
+# Keys live in a database of their own, created here db -> collection ->
+# documents. Not restheart-test: that one holds users and acl and is not a place
+# to be creating arbitrary collections in.
+#
+# The documents are written with PUT and `wm=upsert`. Without the write mode a
+# PUT on a document that does not exist yet answers 404, since the default mode
+# updates rather than creates — and upsert is also what makes this setup
+# re-runnable, where a POST would add four more keys on every run.
+
+Background:
+  * url 'http://localhost:8080'
+  * def basic =
+  """
+  function(creds) {
+  var temp = creds.username + ':' + creds.password;
+  var Base64 = Java.type('java.util.Base64');
+  var encoded = Base64.getEncoder().encodeToString(temp.toString().getBytes());
+  return 'Basic ' + encoded;
+  }
+  """
+
+  * def admin = basic({username: 'admin', password: 'secret'})
+
+Scenario: Create the test-apikeys db and seed the keys
+
+  * header Authorization = admin
+  Given path 'test-apikeys'
+  When method PUT
+  Then assert responseStatus == 201 || responseStatus == 200
+
+  * header Authorization = admin
+  Given path 'test-apikeys/keys'
+  When method PUT
+  Then assert responseStatus == 201 || responseStatus == 200
+
+  # A working key. `admin` is the role the test ACL grants path-prefix "/" to,
+  # so this one can reach /secho.
+  * header Authorization = admin
+  Given path 'test-apikeys/keys/valid'
+  And param wm = 'upsert'
+  And request
+  """
+  {
+    "hash": "cff1ff8ac100e099a885d9079ebe17919408763bca38289196d38490f335ff42",
+    "user": "admin",
+    "roles": ["admin"]
+  }
+  """
+  When method PUT
+  Then assert responseStatus == 201 || responseStatus == 200
+
+  # Same principal, no roles at all. Deny-by-default made observable: the
+  # request authenticates and then reaches nothing.
+  * header Authorization = admin
+  Given path 'test-apikeys/keys/noroles'
+  And param wm = 'upsert'
+  And request
+  """
+  {
+    "hash": "a6c408d4deabb91ca3e358f28ba7e21526249bb352e82696958b0bc30924fd45",
+    "user": "admin",
+    "roles": []
+  }
+  """
+  When method PUT
+  Then assert responseStatus == 201 || responseStatus == 200
+
+  # Expired an hour ago. Present in the collection on purpose: a TTL index
+  # reclaims lazily, so the authenticator has to refuse it on its own.
+  * header Authorization = admin
+  Given path 'test-apikeys/keys/expired'
+  And param wm = 'upsert'
+  And request
+  """
+  {
+    "hash": "c8f0f2bb100cea93d40356502f09746413f4ebcffc2b2c411cdd9657d0af23c8",
+    "user": "admin",
+    "roles": ["admin"],
+    "expiresAt": { "$date": 1000000000000 }
+  }
+  """
+  When method PUT
+  Then assert responseStatus == 201 || responseStatus == 200
+
+  # A narrower role. The test ACL grants poweruser only GET /testdb, so this key
+  # is what shows that the *specific* roles on the key document drive
+  # authorization — not merely that some role arrived.
+  * header Authorization = admin
+  Given path 'test-apikeys/keys/poweruser'
+  And param wm = 'upsert'
+  And request
+  """
+  {
+    "hash": "ca8dcb2d445daf0ce1415b6e3a87c5da3bf5811281dfd87592d61569e8d9f994",
+    "user": "admin",
+    "roles": ["poweruser"]
+  }
+  """
+  When method PUT
+  Then assert responseStatus == 201 || responseStatus == 200

--- a/core/src/test/java/karate/api-key-auth.feature
+++ b/core/src/test/java/karate/api-key-auth.feature
@@ -1,0 +1,84 @@
+Feature: test apiKeyAuthMechanism
+
+# What the unit tests cannot reach.
+#
+# ApiKeyAuthMechanismTest exercises the mechanism against a stub authenticator,
+# in isolation. The claim the whole design rests on is a different one: that this
+# mechanism and jwtAuthenticationMechanism share the Bearer scheme in a running
+# instance, in the right order. That order comes from @RegisterPlugin(priority)
+# via PluginsFactory -> PluginsRegistryImpl -> AuthenticatorMechanismsHandler,
+# and was established by reading the code rather than by observing it.
+#
+# If that reasoning were wrong, every unit test would still pass and the feature
+# would be broken — the JWT mechanism would answer NOT_AUTHENTICATED for a key
+# and end the chain. Hence the first two scenarios below, which are the point of
+# this file; the rest is behaviour that is cheaper to pin here than to mock.
+
+Background:
+  * callonce read('api-key-auth-setup.feature')
+  * url 'http://localhost:8080'
+
+  # roles: [admin], alg=HS256, key=secret — the same token jwt-auth.feature uses
+  * def jwt = 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJyZXN0aGVhcnQub3JnIiwicm9sZXMiOlsiYWRtaW4iXSwiZXh0cmEiOnsiYSI6MSwiYiI6Mn19.vDaJOoPH5EnAiyM6lF737vqgi978S2GIAQe1gq33eDU'
+
+Scenario: a JWT still authenticates with apiKeyAuthMechanism enabled ahead of it
+    # The regression that matters. Enabling a mechanism that also reads Bearer
+    # must not change the outcome of a request that carries a JWT.
+    * header Authorization = jwt
+    Given path '/secho'
+    When method GET
+    Then status 200
+
+Scenario: an API key authenticates under the same Bearer scheme
+    * header Authorization = 'Bearer rhak_valid'
+    Given path '/secho'
+    When method GET
+    Then status 200
+
+Scenario: the specific roles on the key drive authorization
+    # The test ACL grants poweruser GET /testdb and nothing else, so this key
+    # reaching one and not the other shows the roles came from the key document
+    # rather than from the user it belongs to — that user is `admin`, who would
+    # have reached both.
+    * header Authorization = 'Bearer rhak_poweruser'
+    Given path '/testdb'
+    When method GET
+    Then assert responseStatus == 200 || responseStatus == 404
+
+    * header Authorization = 'Bearer rhak_poweruser'
+    Given path '/secho'
+    When method GET
+    Then status 403
+
+Scenario: a key naming no roles authenticates but reaches nothing
+    # Deny-by-default, end to end: authentication succeeds — so this is 403 and
+    # not 401 — and then the ACL matches nothing.
+    * header Authorization = 'Bearer rhak_noroles'
+    Given path '/secho'
+    When method GET
+    Then status 403
+
+Scenario: an expired key is refused even though it is still in the collection
+    * header Authorization = 'Bearer rhak_expired'
+    Given path '/secho'
+    When method GET
+    Then status 401
+
+Scenario: an unknown key with the prefix is refused rather than passed on
+    * header Authorization = 'Bearer rhak_nosuchkey'
+    Given path '/secho'
+    When method GET
+    Then status 401
+
+Scenario: a Bearer value with no prefix is left to the JWT mechanism
+    # Not ours, so we decline; the JWT mechanism owns the answer and the answer
+    # is 401. What must not happen is this reaching the key lookup.
+    * header Authorization = 'Bearer not-a-token'
+    Given path '/secho'
+    When method GET
+    Then status 401
+
+Scenario: no Authorization header at all
+    Given path '/secho'
+    When method GET
+    Then status 401

--- a/core/src/test/resources/etc/conf-overrides.yml
+++ b/core/src/test/resources/etc/conf-overrides.yml
@@ -14,6 +14,21 @@
 /jwtAuthenticationMechanism/rolesClaim: roles
 /jwtAuthenticationMechanism/base64Encoded: false
 
+# apiKeyAuthMechanism shares the Bearer scheme with jwtAuthenticationMechanism: it runs
+# first (priority) and declines, with NOT_ATTEMPTED, anything not carrying the prefix.
+# Both are enabled here so api-key-auth.feature can prove they actually compose in a
+# running instance — the one claim the unit tests structurally cannot reach.
+/apiKeyAuthMechanism/enabled: true
+/apiKeyAuthMechanism/authenticator: mongoApiKeyAuthenticator
+/apiKeyAuthMechanism/prefix: rhak_
+
+/mongoApiKeyAuthenticator/enabled: true
+/mongoApiKeyAuthenticator/keys-db: test-apikeys
+/mongoApiKeyAuthenticator/keys-collection: keys
+# Off so the feature seeds keys and uses them immediately, and so a revocation test
+# would not have to wait out a TTL.
+/mongoApiKeyAuthenticator/cache-enabled: false
+
 /jwtConfigProvider/enabled: true
 /jwtConfigProvider/key: secret
 /jwtConfigProvider/algorithm: HS256

--- a/security/src/main/java/org/restheart/security/authenticators/MongoApiKeyAuthenticator.java
+++ b/security/src/main/java/org/restheart/security/authenticators/MongoApiKeyAuthenticator.java
@@ -1,0 +1,325 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-security
+ * %%
+ * Copyright (C) 2018 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+package org.restheart.security.authenticators;
+
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Updates.currentDate;
+
+import java.nio.CharBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+import org.restheart.cache.Cache;
+import org.restheart.cache.CacheFactory;
+import org.restheart.cache.LoadingCache;
+import org.restheart.configuration.ConfigurationException;
+import org.restheart.plugins.Inject;
+import org.restheart.plugins.OnInit;
+import org.restheart.plugins.RegisterPlugin;
+import org.restheart.plugins.security.Authenticator;
+import org.restheart.security.ApiKeyCredential;
+import org.restheart.security.MongoRealmAccount;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mongodb.client.MongoClient;
+
+import io.undertow.security.idm.Account;
+import io.undertow.security.idm.Credential;
+
+/**
+ * Verifies an {@link ApiKeyCredential} against a MongoDB collection.
+ *
+ * <h2>Why this is not {@code mongoRealmAuthenticator} with another property</h2>
+ *
+ * <p>An API key is a different kind of credential from a password, and most of
+ * what follows falls out of that: it is high-entropy rather than memorable, it
+ * is looked up <em>by itself</em> rather than by a principal, it expires, it is
+ * revoked one at a time, and it grants less than the user who created it.
+ *
+ * <h2>SHA-256, not bcrypt</h2>
+ *
+ * <p>Copying {@code mongoRealmAuthenticator}'s bcrypt would be the obvious
+ * thing and the wrong one. bcrypt is deliberately slow, and that slowness is
+ * the defence for a low-entropy secret a human chose. A key is 32 random bytes:
+ * brute force is not the threat, and the cost is real — bcrypt at complexity 12
+ * is tens of milliseconds, paid on <em>every request</em> rather than once per
+ * login.
+ *
+ * <h2>Roles come from the key, never from the user</h2>
+ *
+ * <p>The account built here carries the roles named on the key document. That
+ * makes a key deny-by-default: an ACL written for {@code user} does not match a
+ * key whose role is something else, so a key reaches only what was granted to
+ * it deliberately. Getting it wrong yields a key that cannot do enough — not
+ * one that can do too much.
+ *
+ * <p>A key document naming no roles produces an account with no roles. It must
+ * never fall back to the user's.
+ *
+ * @author Andrea Di Cesare {@literal <andrea@softinstigate.com>}
+ */
+@RegisterPlugin(name = "mongoApiKeyAuthenticator",
+        description = "authenticates API keys stored in a MongoDB collection",
+        enabledByDefault = false)
+public class MongoApiKeyAuthenticator implements Authenticator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MongoApiKeyAuthenticator.class);
+
+    private static final String SHA_256 = "SHA-256";
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+    @Inject("config")
+    private Map<String, Object> config;
+
+    @Inject("mclient")
+    private MongoClient mclient;
+
+    private String keysDb;
+    private String keysCollection;
+    private String propHash;
+    private String propPrincipal;
+    private String propRoles;
+    private String propExpires;
+    private boolean trackLastUsed;
+
+    private LoadingCache<String, MongoRealmAccount> keysCache = null;
+
+    @OnInit
+    public void init() throws ConfigurationException {
+        this.keysDb = argOrDefault(config, "keys-db", "restheart");
+        this.keysCollection = argOrDefault(config, "keys-collection", "apiKeys");
+        this.propHash = argOrDefault(config, "prop-hash", "hash");
+        this.propPrincipal = argOrDefault(config, "prop-principal", "user");
+        this.propRoles = argOrDefault(config, "prop-roles", "roles");
+        this.propExpires = argOrDefault(config, "prop-expires", "expiresAt");
+        this.trackLastUsed = argOrDefault(config, "track-last-used", true);
+
+        final boolean cacheEnabled = argOrDefault(config, "cache-enabled", true);
+
+        if (cacheEnabled) {
+            final int cacheSize = argOrDefault(config, "cache-size", 1000);
+            final int cacheTTL = argOrDefault(config, "cache-ttl", 60_000);
+            final String expirePolicy = argOrDefault(config, "cache-expire-policy", "AFTER_WRITE");
+
+            final Cache.EXPIRE_POLICY policy;
+            try {
+                policy = Cache.EXPIRE_POLICY.valueOf(expirePolicy);
+            } catch (final IllegalArgumentException iae) {
+                throw new ConfigurationException("wrong configuration of mongoApiKeyAuthenticator, "
+                    + "cache-expire-policy is not valid: " + expirePolicy);
+            }
+
+            // Revocation takes effect within this TTL. Revocation immediacy is
+            // most of what a key offers over a password, so a long cache
+            // quietly gives away the feature — hence the short default.
+            this.keysCache = CacheFactory.createLocalLoadingCache(cacheSize, policy, cacheTTL, this::findKey);
+        }
+    }
+
+    @Override
+    public Account verify(final Credential credential) {
+        if (!(credential instanceof final ApiKeyCredential apiKey)) {
+            return null;
+        }
+
+        if (this.mclient == null) {
+            LOGGER.error("Cannot verify API key: mongo service is not enabled.");
+            return null;
+        }
+
+        final var hash = sha256(apiKey.getKey());
+
+        if (hash == null) {
+            return null;
+        }
+
+        final var account = this.keysCache == null
+            ? findKey(hash)
+            : this.keysCache.getLoading(hash).orElse(null);
+
+        if (account == null) {
+            LOGGER.debug("API key not found");
+            return null;
+        }
+
+        if (this.trackLastUsed) {
+            touch(hash);
+        }
+
+        return account;
+    }
+
+    /**
+     * Not supported: an API key is self-identifying, so there is no principal to
+     * verify it against. Answering anything else here would let a caller pass a
+     * key as somebody else's credential.
+     */
+    @Override
+    public Account verify(final String id, final Credential credential) {
+        return null;
+    }
+
+    @Override
+    public Account verify(final Account account) {
+        return account;
+    }
+
+    /**
+     * Loads the key document and builds the account, or {@code null} when the
+     * key is unknown or spent.
+     */
+    private MongoRealmAccount findKey(final String hash) {
+        final var coll = mclient.getDatabase(this.keysDb)
+            .getCollection(this.keysCollection)
+            .withDocumentClass(BsonDocument.class);
+
+        final BsonDocument key;
+
+        try {
+            key = coll.find(eq(this.propHash, hash)).first();
+        } catch (final Throwable t) {
+            LOGGER.error("Error finding API key in {}.{}", this.keysDb, this.keysCollection, t);
+            return null;
+        }
+
+        if (key == null) {
+            return null;
+        }
+
+        // Checked here as well as by the TTL index: a TTL index reclaims lazily,
+        // on a background sweep, so a just-expired key can still be present.
+        if (isExpired(key)) {
+            LOGGER.debug("API key is expired");
+            return null;
+        }
+
+        final var principal = key.get(this.propPrincipal);
+
+        if (principal == null || !principal.isString() || principal.asString().getValue().isBlank()) {
+            LOGGER.warn("API key document has no usable '{}' property", this.propPrincipal);
+            return null;
+        }
+
+        return new MongoRealmAccount(this.keysDb,
+            principal.asString().getValue(),
+            new char[0],
+            rolesOf(key),
+            new BsonDocument());
+    }
+
+    /**
+     * The roles named on the key document — never the user's. An absent or
+     * malformed property yields no roles, which is the safe reading.
+     */
+    // package-private so the rule below can be pinned by a test
+    Set<String> rolesOf(final BsonDocument key) {
+        final var roles = new LinkedHashSet<String>();
+        final var value = key.get(this.propRoles);
+
+        if (value != null && value.isArray()) {
+            for (final BsonValue role : value.asArray()) {
+                if (role.isString()) {
+                    roles.add(role.asString().getValue());
+                }
+            }
+        }
+
+        if (roles.isEmpty()) {
+            LOGGER.warn("API key for '{}' names no roles; it will be able to reach only what is "
+                + "granted to no role at all", key.get(this.propPrincipal));
+        }
+
+        return roles;
+    }
+
+    boolean isExpired(final BsonDocument key) {
+        final var expires = key.get(this.propExpires);
+
+        if (expires == null || expires.isNull()) {
+            return false;
+        }
+
+        if (expires.isDateTime()) {
+            return expires.asDateTime().getValue() <= System.currentTimeMillis();
+        }
+
+        LOGGER.warn("API key '{}' property is not a date; treating the key as expired", this.propExpires);
+        return true;
+    }
+
+    /**
+     * Records that the key was used.
+     *
+     * <p>Deliberately fire-and-forget: this is bookkeeping, and a failure to
+     * write it must never turn a valid key into a rejected one.
+     */
+    private void touch(final String hash) {
+        try {
+            mclient.getDatabase(this.keysDb)
+                .getCollection(this.keysCollection)
+                .withDocumentClass(BsonDocument.class)
+                .updateOne(eq(this.propHash, hash), currentDate("lastUsedAt"));
+        } catch (final Throwable t) {
+            LOGGER.warn("Could not update lastUsedAt for an API key", t);
+        }
+    }
+
+    /**
+     * Hex-encoded SHA-256 of the key.
+     *
+     * <p>Encoded through a {@link ByteBuffer} rather than {@code new String(key)}
+     * so the secret never becomes a {@code String} — one would sit in the heap
+     * until it happened to be collected, which is the reason the credential
+     * holds a {@code char[]} in the first place.
+     */
+    static String sha256(final char[] key) {
+        final var encoded = StandardCharsets.UTF_8.encode(CharBuffer.wrap(key));
+        final var bytes = new byte[encoded.remaining()];
+        encoded.get(bytes);
+
+        try {
+            final var digest = MessageDigest.getInstance(SHA_256).digest(bytes);
+            final var hex = new char[digest.length * 2];
+
+            for (int i = 0; i < digest.length; i++) {
+                hex[i * 2] = HEX[(digest[i] >> 4) & 0xf];
+                hex[i * 2 + 1] = HEX[digest[i] & 0xf];
+            }
+
+            return new String(hex);
+        } catch (final NoSuchAlgorithmException nsae) {
+            LOGGER.error("{} is not available", SHA_256, nsae);
+            return null;
+        } finally {
+            Arrays.fill(bytes, (byte) 0);
+            if (encoded.hasArray()) {
+                Arrays.fill(encoded.array(), (byte) 0);
+            }
+        }
+    }
+}

--- a/security/src/main/java/org/restheart/security/mechanisms/ApiKeyAuthMechanism.java
+++ b/security/src/main/java/org/restheart/security/mechanisms/ApiKeyAuthMechanism.java
@@ -1,0 +1,170 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-security
+ * %%
+ * Copyright (C) 2018 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+package org.restheart.security.mechanisms;
+
+import java.util.Map;
+
+import org.restheart.configuration.ConfigurationException;
+import org.restheart.plugins.Inject;
+import org.restheart.plugins.OnInit;
+import org.restheart.plugins.PluginsRegistry;
+import org.restheart.plugins.RegisterPlugin;
+import org.restheart.plugins.security.AuthMechanism;
+import org.restheart.plugins.security.Authenticator;
+import org.restheart.security.ApiKeyCredential;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.undertow.security.api.SecurityContext;
+import io.undertow.server.HttpServerExchange;
+import static io.undertow.util.Headers.AUTHORIZATION;
+
+/**
+ * Authenticates requests bearing a long-lived, opaque API key.
+ *
+ * <p>The key travels in the standard {@code Authorization: Bearer} header
+ * (RFC 6750) rather than a scheme of its own, so every client library, curl
+ * example and CI tool works without being told about a custom one.
+ *
+ * <h2>Sharing {@code Bearer} with {@code jwtAuthenticationMechanism}</h2>
+ *
+ * <p>Two mechanisms reading one scheme is an established pattern here, not a
+ * conflict: {@code tokenBasicAuthMechanism} already shares {@code Basic} with
+ * {@code basicAuthMechanism} by running first and declining what is not its
+ * own. This does the same for {@code Bearer}.
+ *
+ * <p><b>The prefix is the claim.</b> A {@code Bearer} value that does not start
+ * with the configured prefix is answered {@code NOT_ATTEMPTED} and falls
+ * through to {@code jwtAuthenticationMechanism}, which keeps its present
+ * behaviour untouched — including {@code NOT_AUTHENTICATED} for a malformed
+ * JWT, so a truncated token is still reported as a bad JWT rather than as a bad
+ * API key.
+ *
+ * <p>The ordering that makes this work is the {@code priority} below:
+ * {@code PluginsFactory} sorts plugin descriptors by it and collects them with
+ * {@code forEachOrdered}, and that order survives into
+ * {@code AuthenticatorMechanismsHandler}. This mechanism must see a request
+ * before the JWT one does, because the JWT mechanism answers
+ * {@code NOT_AUTHENTICATED} — which ends the chain — for anything under
+ * {@code Bearer} that does not decode as a JWT.
+ *
+ * @author Andrea Di Cesare {@literal <andrea@softinstigate.com>}
+ */
+@RegisterPlugin(name = "apiKeyAuthMechanism",
+        description = "authenticates requests bearing an API key, verified by the configured Authenticator",
+        enabledByDefault = false,
+        // Ahead of jwtAuthenticationMechanism (default 10). What matters is
+        // only that it runs first; it claims a disjoint set of Bearer values,
+        // so it competes with nothing.
+        priority = Integer.MIN_VALUE)
+public class ApiKeyAuthMechanism implements AuthMechanism {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiKeyAuthMechanism.class);
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final int BEARER_PREFIX_LENGTH = BEARER_PREFIX.length();
+
+    @Inject("registry")
+    private PluginsRegistry registry;
+
+    @Inject("config")
+    private Map<String, Object> config;
+
+    private Authenticator authenticator;
+    private String prefix;
+
+    @OnInit
+    public void init() throws ConfigurationException {
+        this.prefix = arg(config, "prefix");
+
+        if (this.prefix == null || this.prefix.isBlank()) {
+            throw new ConfigurationException(
+                "apiKeyAuthMechanism requires a non-empty 'prefix'; it is what tells an API key "
+                + "from a JWT under the same Bearer scheme");
+        }
+
+        final String authenticatorName = arg(config, "authenticator");
+        final var record = registry.getAuthenticator(authenticatorName);
+
+        if (record == null) {
+            throw new ConfigurationException(
+                "apiKeyAuthMechanism is configured with authenticator '" + authenticatorName
+                + "' which is not enabled or does not exist");
+        }
+
+        this.authenticator = record.getInstance();
+    }
+
+    @Override
+    public AuthenticationMechanismOutcome authenticate(final HttpServerExchange exchange, final SecurityContext securityContext) {
+        final var authHeaders = exchange.getRequestHeaders().get(AUTHORIZATION);
+
+        if (authHeaders == null) {
+            return AuthenticationMechanismOutcome.NOT_ATTEMPTED;
+        }
+
+        for (final var current : authHeaders) {
+            if (current == null || !current.startsWith(BEARER_PREFIX)) {
+                continue;
+            }
+
+            final var token = current.substring(BEARER_PREFIX_LENGTH);
+
+            // Not ours. Leave it for jwtAuthenticationMechanism — this is the
+            // whole reason a prefix is required rather than optional.
+            if (!token.startsWith(this.prefix)) {
+                continue;
+            }
+
+            final var credential = new ApiKeyCredential(token);
+
+            try {
+                final var account = this.authenticator.verify(credential);
+
+                if (account != null) {
+                    securityContext.authenticationComplete(account, getMechanismName(), false);
+                    return AuthenticationMechanismOutcome.AUTHENTICATED;
+                }
+
+                // The prefix said this is an API key, so we own the failure.
+                // Falling through would gain nothing — it is definitely not a
+                // JWT — and would replace a truthful answer with a confusing one.
+                LOGGER.debug("API key not verified");
+                securityContext.authenticationFailed("API key not verified", getMechanismName());
+                return AuthenticationMechanismOutcome.NOT_AUTHENTICATED;
+            } finally {
+                credential.clear();
+            }
+        }
+
+        return AuthenticationMechanismOutcome.NOT_ATTEMPTED;
+    }
+
+    /**
+     * An API key is not an interactive credential, so this must not invite a
+     * browser to prompt: no {@code WWW-Authenticate}, and the status code is
+     * returned in the result rather than set here, since other mechanisms may
+     * still run.
+     */
+    @Override
+    public ChallengeResult sendChallenge(final HttpServerExchange exchange, final SecurityContext securityContext) {
+        return new ChallengeResult(true, 200);
+    }
+}

--- a/security/src/test/java/org/restheart/security/authenticators/MongoApiKeyAuthenticatorTest.java
+++ b/security/src/test/java/org/restheart/security/authenticators/MongoApiKeyAuthenticatorTest.java
@@ -1,0 +1,157 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-security
+ * %%
+ * Copyright (C) 2018 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+package org.restheart.security.authenticators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Set;
+
+import org.bson.BsonArray;
+import org.bson.BsonBoolean;
+import org.bson.BsonDateTime;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonNull;
+import org.bson.BsonString;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.restheart.security.ApiKeyCredential;
+
+public class MongoApiKeyAuthenticatorTest {
+
+    private MongoApiKeyAuthenticator authenticator;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        this.authenticator = new MongoApiKeyAuthenticator();
+        set("propRoles", "roles");
+        set("propExpires", "expiresAt");
+        set("propPrincipal", "user");
+    }
+
+    private void set(final String field, final Object value) throws Exception {
+        final var f = MongoApiKeyAuthenticator.class.getDeclaredField(field);
+        f.setAccessible(true);
+        f.set(this.authenticator, value);
+    }
+
+    private static BsonDocument key() {
+        return new BsonDocument("user", new BsonString("robot"));
+    }
+
+    // ── hashing ──────────────────────────────────────────────────────────────
+
+    @Test
+    void sha256MatchesAKnownVector() {
+        // echo -n "abc" | shasum -a 256
+        assertEquals("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            MongoApiKeyAuthenticator.sha256("abc".toCharArray()));
+    }
+
+    @Test
+    void sha256IsStableAndNarrow() {
+        final var a = MongoApiKeyAuthenticator.sha256("rhak_7f2c9a".toCharArray());
+
+        assertEquals(a, MongoApiKeyAuthenticator.sha256("rhak_7f2c9a".toCharArray()));
+        assertEquals(64, a.length(), "hex-encoded SHA-256");
+        // The prefix is part of what is hashed: two keys differing only there
+        // must not collide.
+        assertFalse(a.equals(MongoApiKeyAuthenticator.sha256("rhak_7f2c9b".toCharArray())));
+    }
+
+    @Test
+    void sha256HandlesNonAsciiWithoutMangling() {
+        // Encoded as UTF-8 rather than by narrowing chars to bytes, which would
+        // silently collapse anything above U+00FF.
+        final var a = MongoApiKeyAuthenticator.sha256("kéy".toCharArray());
+        final var b = MongoApiKeyAuthenticator.sha256("key".toCharArray());
+
+        assertFalse(a.equals(b));
+    }
+
+    // ── roles ────────────────────────────────────────────────────────────────
+
+    @Test
+    void rolesComeFromTheKey() {
+        final var doc = key().append("roles", new BsonArray(java.util.List.<org.bson.BsonValue>of(
+            new BsonString("cli"), new BsonString("reader"))));
+
+        assertEquals(Set.of("cli", "reader"), this.authenticator.rolesOf(doc));
+    }
+
+    @Test
+    void aKeyWithNoRolesGetsNoRoles() {
+        // The security property: never fall back to the user's roles. A key that
+        // names none must reach only what is granted to no role at all.
+        assertTrue(this.authenticator.rolesOf(key()).isEmpty());
+    }
+
+    @Test
+    void malformedRolesAreIgnoredRatherThanGuessed() {
+        assertTrue(this.authenticator.rolesOf(key().append("roles", new BsonString("cli"))).isEmpty());
+        assertEquals(Set.of("cli"), this.authenticator.rolesOf(key().append("roles",
+            new BsonArray(java.util.List.<org.bson.BsonValue>of(new BsonString("cli"), new BsonInt32(7))))));
+    }
+
+    // ── expiry ───────────────────────────────────────────────────────────────
+
+    @Test
+    void aKeyWithNoExpiryNeverExpires() {
+        assertFalse(this.authenticator.isExpired(key()));
+        assertFalse(this.authenticator.isExpired(key().append("expiresAt", BsonNull.VALUE)));
+    }
+
+    @Test
+    void expiryIsCheckedInCodeNotOnlyByTheTtlIndex() {
+        // A TTL index reclaims lazily, on a background sweep, so a just-expired
+        // key can still be present in the collection.
+        final var past = new BsonDateTime(System.currentTimeMillis() - 1000);
+        final var future = new BsonDateTime(System.currentTimeMillis() + 60_000);
+
+        assertTrue(this.authenticator.isExpired(key().append("expiresAt", past)));
+        assertFalse(this.authenticator.isExpired(key().append("expiresAt", future)));
+    }
+
+    @Test
+    void anUnreadableExpiryIsTreatedAsExpired() {
+        // Fail closed: a key whose expiry cannot be read is not a key that
+        // should keep working.
+        assertTrue(this.authenticator.isExpired(key().append("expiresAt", new BsonBoolean(false))));
+        assertTrue(this.authenticator.isExpired(key().append("expiresAt", new BsonString("tomorrow"))));
+    }
+
+    // ── the SPI's other verify() forms ───────────────────────────────────────
+
+    @Test
+    void verifyByPrincipalIsRefused() {
+        // A key is self-identifying. Accepting a principal here would let a
+        // caller present a key as somebody else's credential.
+        assertNull(this.authenticator.verify("robot", new ApiKeyCredential("rhak_7f2c9a")));
+    }
+
+    @Test
+    void aCredentialThatIsNotAKeyIsDeclined() {
+        assertNull(this.authenticator.verify(new io.undertow.security.idm.PasswordCredential("pwd".toCharArray())));
+    }
+}

--- a/security/src/test/java/org/restheart/security/mechanisms/ApiKeyAuthMechanismTest.java
+++ b/security/src/test/java/org/restheart/security/mechanisms/ApiKeyAuthMechanismTest.java
@@ -1,0 +1,178 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-security
+ * %%
+ * Copyright (C) 2018 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+package org.restheart.security.mechanisms;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.restheart.plugins.security.Authenticator;
+import org.restheart.security.ApiKeyCredential;
+import org.restheart.security.BaseAccount;
+
+import io.undertow.security.api.AuthenticationMechanism.AuthenticationMechanismOutcome;
+import io.undertow.security.api.SecurityContext;
+import io.undertow.security.idm.Account;
+import io.undertow.security.idm.Credential;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HeaderMap;
+import io.undertow.util.Headers;
+
+/**
+ * The property under test is the one that makes this mechanism additive: enabling
+ * it must never change the outcome of a request that does not present a key with
+ * its prefix. Everything else it does follows from that.
+ */
+public class ApiKeyAuthMechanismTest {
+
+    private static final String PREFIX = "rhak_";
+    private static final String GOOD_KEY = PREFIX + "7f2c9a";
+
+    /** Accepts exactly one key and records what it was asked. */
+    private static class StubAuthenticator implements Authenticator {
+        private final Account account = new BaseAccount("robot", Set.of("cli"));
+        String seen = null;
+
+        @Override
+        public Account verify(final Credential credential) {
+            this.seen = new String(((ApiKeyCredential) credential).getKey());
+            return GOOD_KEY.equals(this.seen) ? this.account : null;
+        }
+
+        @Override
+        public Account verify(final String id, final Credential credential) {
+            return null;
+        }
+
+        @Override
+        public Account verify(final Account account) {
+            return account;
+        }
+    }
+
+    private ApiKeyAuthMechanism mechanism;
+    private StubAuthenticator authenticator;
+    private SecurityContext securityContext;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        this.authenticator = new StubAuthenticator();
+        this.securityContext = mock(SecurityContext.class);
+        this.mechanism = new ApiKeyAuthMechanism();
+
+        // init() resolves the authenticator through the plugins registry, which
+        // is not available here; set what it would have produced.
+        set(this.mechanism, "prefix", PREFIX);
+        set(this.mechanism, "authenticator", this.authenticator);
+    }
+
+    private static void set(final Object target, final String field, final Object value) throws Exception {
+        final var f = target.getClass().getDeclaredField(field);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    private AuthenticationMechanismOutcome authenticate(final String authorization) {
+        final var exchange = mock(HttpServerExchange.class);
+        final var headers = new HeaderMap();
+
+        if (authorization != null) {
+            headers.put(Headers.AUTHORIZATION, authorization);
+        }
+
+        when(exchange.getRequestHeaders()).thenReturn(headers);
+
+        return this.mechanism.authenticate(exchange, this.securityContext);
+    }
+
+    @Test
+    void noAuthorizationHeaderIsNotAttempted() {
+        assertEquals(AuthenticationMechanismOutcome.NOT_ATTEMPTED, authenticate(null));
+        assertNull(this.authenticator.seen, "the authenticator must not be consulted");
+    }
+
+    @Test
+    void basicIsNotAttempted() {
+        assertEquals(AuthenticationMechanismOutcome.NOT_ATTEMPTED, authenticate("Basic dXNlcjpwd2Q="));
+        assertNull(this.authenticator.seen);
+    }
+
+    @Test
+    void aBearerJwtIsLeftToTheJwtMechanism() {
+        // The whole reason the prefix is required. A JWT under Bearer must reach
+        // jwtAuthenticationMechanism untouched, so this has to decline rather
+        // than fail — a failure would end the chain before it got there.
+        final var jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhbGljZSJ9.c2ln";
+
+        assertEquals(AuthenticationMechanismOutcome.NOT_ATTEMPTED, authenticate("Bearer " + jwt));
+        assertNull(this.authenticator.seen);
+        verify(this.securityContext, never())
+            .authenticationFailed(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void aMalformedBearerValueIsAlsoLeftAlone() {
+        // Not a JWT either, but still not ours — jwtAuthenticationMechanism owns
+        // the answer, and it is the one that can say "malformed JWT".
+        assertEquals(AuthenticationMechanismOutcome.NOT_ATTEMPTED, authenticate("Bearer not-a-token"));
+        assertNull(this.authenticator.seen);
+    }
+
+    @Test
+    void aPrefixedKeyIsVerified() {
+        assertEquals(AuthenticationMechanismOutcome.AUTHENTICATED, authenticate("Bearer " + GOOD_KEY));
+        assertEquals(GOOD_KEY, this.authenticator.seen, "the prefix is part of the key, not stripped");
+        verify(this.securityContext)
+            .authenticationComplete(ArgumentMatchers.any(Account.class), ArgumentMatchers.anyString(),
+                ArgumentMatchers.anyBoolean());
+    }
+
+    @Test
+    void anUnknownPrefixedKeyFailsRatherThanFallingThrough() {
+        // We claimed it by prefix, so we own the failure. Falling through would
+        // gain nothing — it is definitely not a JWT — and would replace a
+        // truthful answer with a confusing one.
+        assertEquals(AuthenticationMechanismOutcome.NOT_AUTHENTICATED, authenticate("Bearer " + PREFIX + "unknown"));
+        assertEquals(PREFIX + "unknown", this.authenticator.seen);
+    }
+
+    @Test
+    void theChallengeIsNotInteractive() {
+        // An API key is not something a human types into a browser dialog, so
+        // this must not produce a WWW-Authenticate.
+        final var exchange = mock(HttpServerExchange.class);
+        final var result = this.mechanism.sendChallenge(exchange, this.securityContext);
+
+        assertTrue(result.isChallengeSent());
+        // No WWW-Authenticate is set: the mechanism touches no response header
+        // at all, which is what keeps a browser from popping a native dialog.
+        assertEquals(200, result.getDesiredResponseCode());
+    }
+}


### PR DESCRIPTION
Closes #699, closes #700.

RESTHeart ships Basic, Digest, JWT and TokenBasic, and none of them authenticates a long-lived, revocable, per-user credential — the shape every deployment reaches for as soon as something other than a browser calls the API. The gap is sharpest under federated identity: a user who signed up through OAuth has no password, so there is nothing for Basic to carry and nothing for a token endpoint to exchange.

Two plugins, both disabled by default:

- **`apiKeyAuthMechanism`** — extracts the key, delegates verification
- **`mongoApiKeyAuthenticator`** — verifies it against a MongoDB collection, with expiry, revocation and last-used tracking

Plus `ApiKeyCredential` in commons, and default configuration for both.

## Sharing `Bearer` with the JWT mechanism

The key travels as `Authorization: Bearer`, the standard, not a scheme of its own. That needed no change to `JwtAuthenticationMechanism`: `TokenBasicAuthMechanism` already shares `Basic` with `BasicAuthMechanism` by declaring `priority = Integer.MIN_VALUE` and returning `NOT_ATTEMPTED` when the credential is not one of its tokens, and this follows the same pattern.

**The prefix is the claim.** A `Bearer` value without it gets `NOT_ATTEMPTED` and falls through, so a malformed JWT is still reported by the JWT mechanism as a malformed JWT rather than as a bad API key. Ordering is deterministic: `PluginsFactory.createPlugins` sorts descriptors by `@RegisterPlugin(priority)` and collects with `forEachOrdered`, and that order survives into `AuthenticatorMechanismsHandler`.

The discipline is stricter than `TokenBasicAuthMechanism`'s: once the prefix matches we own the credential, so an unknown key is `NOT_AUTHENTICATED`, not a fall-through. That mechanism has to be laxer because a `Basic` header genuinely carries two indistinguishable credential types; a prefixed key is unambiguous, and falling through would replace a truthful "invalid API key" with whatever the next mechanism says.

## Three decisions worth stating, each with an obvious wrong alternative

- **SHA-256, not bcrypt.** bcrypt's slowness is the defence for a low-entropy secret a human chose. A key is 32 random bytes, and the cost would be paid on every request rather than once per login.
- **Roles come from the key document, never the user's.** That makes a key deny-by-default: an ACL written for `user` does not match it, so it reaches only what was granted deliberately. Getting it wrong yields a key that cannot do enough, not one that can do too much. A key naming no roles gets no roles.
- **Expiry is checked in code as well as by a TTL index**, because a TTL index reclaims lazily and a just-expired key can still be present.

The collection is configurable, mirroring `mongoRealmAuthenticator`'s `users-db`/`users-collection`, so a deployment that would rather keep keys in the user document can. The default is a collection of its own: a TTL index only works on a top-level field, and `lastUsedAt` writes would otherwise hit the user document on every request and churn the authenticator's cache.

## Tests

- **18 unit tests** — the mechanism's `NOT_ATTEMPTED`/`NOT_AUTHENTICATED` discipline against a stub authenticator, and the authenticator's hashing, roles and expiry rules.
- **8 Karate scenarios** — what the unit tests structurally cannot reach: that the two mechanisms actually compose in a running instance. A JWT still authenticates with this mechanism enabled ahead of it, and an API key authenticates under the same scheme. The `poweruser` key reaches `GET /testdb` and is refused `403` on `/secho` while belonging to `admin`, who would reach both — so the roles demonstrably come from the key document. The key naming no roles answers `403` rather than `401`: deny-by-default made visible.

`mvn clean verify` passes, integration suite included.

Documentation is already merged: SoftInstigate/restheart-website#49 and #50.
