### PR TITLE
Restrict temp directory permissions and drop a pointless temp file

### DIFF
--- a/commons/src/main/java/org/restheart/utils/ResourcesExtractor.java
+++ b/commons/src/main/java/org/restheart/utils/ResourcesExtractor.java
@@ -32,6 +32,8 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -180,7 +182,7 @@ public class ResourcesExtractor {
 
             try {
                 // used when run as a JAR file
-                Path destinationDir = Files.createTempDirectory("restheart-");
+                Path destinationDir = Files.createTempDirectory("restheart-", ownerOnly());
 
                 ret = destinationDir.toFile();
 
@@ -325,7 +327,7 @@ public class ResourcesExtractor {
      */
     @SuppressWarnings("rawtypes")
     private static File extractNativeImageResource(Class clazz, String resourcePath) throws IOException {
-        Path destinationDir = Files.createTempDirectory("restheart-");
+        Path destinationDir = Files.createTempDirectory("restheart-", ownerOnly());
 
         var index = getNativeImageDirectoryIndex();
         var filesCsv = index.get(resourcePath);
@@ -347,5 +349,22 @@ public class ResourcesExtractor {
         }
 
         return destinationDir.toFile();
+    }
+
+    /**
+     * Owner-only permissions for a temporary directory.
+     *
+     * <p>{@code createTempDirectory} without attributes falls back to the
+     * filesystem default, which in a shared temp directory means anything the
+     * umask allows. Extracted resources are readable by whoever can reach them,
+     * so the permissions are stated rather than inherited.
+     *
+     * <p>Empty on filesystems with no POSIX view — Windows — where asking for
+     * POSIX permissions would throw rather than protect anything.
+     */
+    private static FileAttribute<?>[] ownerOnly() {
+        return FileSystems.getDefault().supportedFileAttributeViews().contains("posix")
+            ? new FileAttribute<?>[] { PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")) }
+            : new FileAttribute<?>[0];
     }
 }

--- a/core/src/main/java/org/restheart/graal/ResourcesScannerFeature.java
+++ b/core/src/main/java/org/restheart/graal/ResourcesScannerFeature.java
@@ -21,6 +21,7 @@ package org.restheart.graal;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
@@ -62,20 +63,17 @@ public class ResourcesScannerFeature implements Feature {
             }
         });
 
-        // Write the directory index as a resource
+        // Write the directory index as a resource.
+        //
+        // This used to round-trip through a temp file — write the string, read it
+        // straight back as bytes, delete it. The file bought nothing, and on the
+        // exception path it was never deleted; handing the bytes over directly is
+        // both simpler and one less file in a shared temp directory.
         if (!directoryIndex.isEmpty()) {
-            try {
-                var tmpFile = Files.createTempFile("restheart-resources-", ".properties");
-                var sb = new StringBuilder();
-                directoryIndex.forEach((dir, files) -> {
-                    sb.append(dir).append("=").append(files).append("\n");
-                });
-                Files.writeString(tmpFile, sb.toString());
-                RuntimeResourceAccess.addResource(ResourcesScannerFeature.class.getModule(), INDEX_RESOURCE, Files.readAllBytes(tmpFile));
-                Files.delete(tmpFile);
-            } catch (IOException e) {
-                System.err.println("[ResourcesScannerFeature] Failed to write directory index: " + e.getMessage());
-            }
+            var sb = new StringBuilder();
+            directoryIndex.forEach((dir, files) -> sb.append(dir).append("=").append(files).append("\n"));
+            RuntimeResourceAccess.addResource(ResourcesScannerFeature.class.getModule(), INDEX_RESOURCE,
+                    sb.toString().getBytes(StandardCharsets.UTF_8));
         }
     }
 


### PR DESCRIPTION
Two SonarCloud CRITICAL vulnerabilities (S5443, *publicly writable directories*), fixed on `9.x` where they actually ship. The same change is on the 9.x→master merge in #702, byte for byte, so future forward-ports see no divergence here.

**`ResourcesScannerFeature`** wrote the directory index to a temp file, read it straight back as bytes, then deleted it. The file bought nothing, and on the exception path it was never deleted. The bytes now go to `addResource` directly — the finding disappears rather than being annotated, and a leak goes with it.

**`ResourcesExtractor`** genuinely needs its temp directory, so the permissions are stated (`rwx------`) instead of inherited from the umask. On filesystems with no POSIX view (Windows) the attribute list is empty, since asking for POSIX permissions there throws rather than protecting anything.

Both `createTempDirectory` calls are fixed, not only the one Sonar flagged — the other, at line 183, has the identical defect and simply falls outside this analysis window.

`mvn clean verify`: 572 tests, zero failures.