### PR TITLE
fix(core): run WildcardInterceptors on the SSE handshake pipeline

### DIFF
--- a/commons/src/main/java/org/restheart/exchange/SseHandshakeRequest.java
+++ b/commons/src/main/java/org/restheart/exchange/SseHandshakeRequest.java
@@ -1,0 +1,76 @@
+package org.restheart.exchange;
+
+import io.undertow.server.HttpServerExchange;
+
+/**
+ * {@link ServiceRequest} implementation used to run {@code WildcardInterceptor}s
+ * on the SSE handshake pipeline (see {@code PluginsRegistryImpl#plugSseService}).
+ *
+ * <p>{@code SseService} is a {@code Plugin}, not an {@code ExchangeTypeResolver}:
+ * it declares no request/response types of its own, so there is no
+ * service-specific {@code ServiceRequest} subtype to attach to the exchange the
+ * way {@code ServiceExchangeInitializer} does for a {@code Service}. This class
+ * fills that gap, wrapping the exchange with just enough of the
+ * {@code ServiceRequest} contract (path, headers, query parameters,
+ * authenticated account) for a {@code WildcardInterceptor} to inspect and
+ * modify, without pretending the SSE handshake has a parseable body.
+ *
+ * <p>The instance is never attached to the exchange, so several can be created
+ * for the same exchange without conflict: the SSE pipeline runs interceptors at
+ * both {@code REQUEST_BEFORE_AUTH} and {@code REQUEST_AFTER_AUTH}, each via its
+ * own executor.
+ *
+ * @author Maurizio Turatti {@literal <maurizio@softinstigate.com>}
+ * @see org.restheart.plugins.WildcardInterceptor
+ * @see SseHandshakeResponse
+ */
+public class SseHandshakeRequest extends ServiceRequest<Object> {
+
+    private SseHandshakeRequest(HttpServerExchange exchange) {
+        super(exchange, true);
+    }
+
+    /**
+     * Factory method to create an {@code SseHandshakeRequest} wrapping the given
+     * HTTP exchange.
+     *
+     * @param exchange the HTTP server exchange to wrap
+     * @return a new {@code SseHandshakeRequest} instance
+     */
+    public static SseHandshakeRequest of(HttpServerExchange exchange) {
+        return new SseHandshakeRequest(exchange);
+    }
+
+    /**
+     * Throws {@link IllegalStateException}: an SSE handshake request has no
+     * parseable content.
+     *
+     * @return this method never returns normally
+     */
+    @Override
+    public Object getContent() {
+        throw new IllegalStateException("the SSE handshake request has no content");
+    }
+
+    /**
+     * Throws {@link IllegalStateException}: an SSE handshake request has no
+     * parseable content.
+     *
+     * @param content the content that would be set (ignored)
+     */
+    @Override
+    public void setContent(Object content) {
+        throw new IllegalStateException("the SSE handshake request has no content");
+    }
+
+    /**
+     * Throws {@link IllegalStateException}: an SSE handshake request has no
+     * parseable content.
+     *
+     * @return this method never returns normally
+     */
+    @Override
+    public Object parseContent() {
+        throw new IllegalStateException("the SSE handshake request has no content");
+    }
+}

--- a/commons/src/main/java/org/restheart/exchange/SseHandshakeRequest.java
+++ b/commons/src/main/java/org/restheart/exchange/SseHandshakeRequest.java
@@ -1,3 +1,23 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-commons
+ * %%
+ * Copyright (C) 2019 - 2026 SoftInstigate
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
 package org.restheart.exchange;
 
 import io.undertow.server.HttpServerExchange;
@@ -15,10 +35,13 @@ import io.undertow.server.HttpServerExchange;
  * authenticated account) for a {@code WildcardInterceptor} to inspect and
  * modify, without pretending the SSE handshake has a parseable body.
  *
- * <p>The instance is never attached to the exchange, so several can be created
- * for the same exchange without conflict: the SSE pipeline runs interceptors at
- * both {@code REQUEST_BEFORE_AUTH} and {@code REQUEST_AFTER_AUTH}, each via its
- * own executor.
+ * <p>The instance is never attached to the exchange under {@code ServiceRequest}'s own
+ * {@code REQUEST_KEY}, so several can be created for the same exchange without conflicting
+ * with other handlers that look the request up that way. The SSE pipeline runs interceptors at
+ * both {@code REQUEST_BEFORE_AUTH} and {@code REQUEST_AFTER_AUTH}, via two invocations of
+ * {@code SseWildcardInterceptorsExecutor}, which itself keeps the two invocations on the same
+ * instance for a given exchange (under its own, dedicated attachment key) so that state set on
+ * the request before auth is still visible after auth.
  *
  * @author Maurizio Turatti {@literal <maurizio@softinstigate.com>}
  * @see org.restheart.plugins.WildcardInterceptor

--- a/commons/src/main/java/org/restheart/exchange/SseHandshakeResponse.java
+++ b/commons/src/main/java/org/restheart/exchange/SseHandshakeResponse.java
@@ -1,3 +1,23 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-commons
+ * %%
+ * Copyright (C) 2019 - 2026 SoftInstigate
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+
 package org.restheart.exchange;
 
 import com.google.gson.JsonObject;
@@ -14,10 +34,16 @@ import io.undertow.server.HttpServerExchange;
  * real, working implementation: the SSE pipeline honors it at
  * {@code REQUEST_AFTER_AUTH} to reject a handshake (for instance, a
  * topic-authorization interceptor denying a subscription), following the same
- * JSON error body shape as {@link JsonResponse}.
+ * JSON error body shape as {@link JsonResponse}, and setting the same
+ * {@code application/json} content type.
  *
- * <p>The instance is never attached to the exchange, so several can be created
- * for the same exchange without conflict.
+ * <p>The instance is never attached to the exchange under {@code ServiceResponse}'s own
+ * {@code RESPONSE_KEY}, so several can be created for the same exchange without conflicting
+ * with other handlers that look the response up that way. {@code SseWildcardInterceptorsExecutor}
+ * keeps its two invocations (one at {@code REQUEST_BEFORE_AUTH}, one at
+ * {@code REQUEST_AFTER_AUTH}) on the same instance for a given exchange, under its own
+ * dedicated attachment key, so a denial raised before auth is still sent, with its status code
+ * and body, after auth.
  *
  * @author Maurizio Turatti {@literal <maurizio@softinstigate.com>}
  * @see org.restheart.plugins.WildcardInterceptor
@@ -55,7 +81,8 @@ public class SseHandshakeResponse extends ServiceResponse<Object> {
     /**
      * Sets the response in an error state, following the same JSON error body
      * shape as {@link JsonResponse#setInError(int, String, Throwable)}:
-     * {@code {"msg": "...", "exception": "..."}}.
+     * {@code {"msg": "...", "exception": "..."}}, and setting the
+     * {@code Content-Type} header to {@code application/json}.
      *
      * @param code the HTTP status code to set (e.g., 401, 403)
      * @param message the error message to include in the response, or null
@@ -65,6 +92,7 @@ public class SseHandshakeResponse extends ServiceResponse<Object> {
     public void setInError(int code, String message, Throwable t) {
         setInError(true);
         setStatusCode(code);
+        setContentTypeAsJson();
 
         var resp = new JsonObject();
 

--- a/commons/src/main/java/org/restheart/exchange/SseHandshakeResponse.java
+++ b/commons/src/main/java/org/restheart/exchange/SseHandshakeResponse.java
@@ -1,0 +1,81 @@
+package org.restheart.exchange;
+
+import com.google.gson.JsonObject;
+
+import io.undertow.server.HttpServerExchange;
+
+/**
+ * {@link ServiceResponse} implementation used to run {@code WildcardInterceptor}s
+ * on the SSE handshake pipeline (see {@code PluginsRegistryImpl#plugSseService}).
+ *
+ * <p>Unlike {@link UninitializedRequest}/{@link UninitializedResponse} (used at
+ * {@code REQUEST_BEFORE_EXCHANGE_INIT}, a stage where denying the request is
+ * out of scope), this class gives {@link #setInError(int, String, Throwable)} a
+ * real, working implementation: the SSE pipeline honors it at
+ * {@code REQUEST_AFTER_AUTH} to reject a handshake (for instance, a
+ * topic-authorization interceptor denying a subscription), following the same
+ * JSON error body shape as {@link JsonResponse}.
+ *
+ * <p>The instance is never attached to the exchange, so several can be created
+ * for the same exchange without conflict.
+ *
+ * @author Maurizio Turatti {@literal <maurizio@softinstigate.com>}
+ * @see org.restheart.plugins.WildcardInterceptor
+ * @see SseHandshakeRequest
+ */
+public class SseHandshakeResponse extends ServiceResponse<Object> {
+
+    private SseHandshakeResponse(HttpServerExchange exchange) {
+        super(exchange, true);
+    }
+
+    /**
+     * Factory method to create an {@code SseHandshakeResponse} wrapping the
+     * given HTTP exchange.
+     *
+     * @param exchange the HTTP server exchange to wrap
+     * @return a new {@code SseHandshakeResponse} instance
+     */
+    public static SseHandshakeResponse of(HttpServerExchange exchange) {
+        return new SseHandshakeResponse(exchange);
+    }
+
+    /**
+     * Returns the string representation of the content set via
+     * {@link #setInError(int, String, Throwable)}, or {@code null} if no
+     * content has been set.
+     *
+     * @return the content as a string, or {@code null}
+     */
+    @Override
+    public String readContent() {
+        return content == null ? null : content.toString();
+    }
+
+    /**
+     * Sets the response in an error state, following the same JSON error body
+     * shape as {@link JsonResponse#setInError(int, String, Throwable)}:
+     * {@code {"msg": "...", "exception": "..."}}.
+     *
+     * @param code the HTTP status code to set (e.g., 401, 403)
+     * @param message the error message to include in the response, or null
+     * @param t an optional throwable whose message will be included in the response
+     */
+    @Override
+    public void setInError(int code, String message, Throwable t) {
+        setInError(true);
+        setStatusCode(code);
+
+        var resp = new JsonObject();
+
+        if (message != null) {
+            resp.addProperty("msg", message);
+        }
+
+        if (t != null) {
+            resp.addProperty("exception", t.getMessage());
+        }
+
+        setContent(resp);
+    }
+}

--- a/core/src/main/java/org/restheart/handlers/SseWildcardInterceptorsExecutor.java
+++ b/core/src/main/java/org/restheart/handlers/SseWildcardInterceptorsExecutor.java
@@ -1,0 +1,174 @@
+package org.restheart.handlers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.restheart.exchange.Exchange;
+import org.restheart.exchange.SseHandshakeRequest;
+import org.restheart.exchange.SseHandshakeResponse;
+import org.restheart.logging.RequestPhaseContext;
+import org.restheart.logging.RequestPhaseContext.Phase;
+import org.restheart.plugins.InterceptPoint;
+import org.restheart.plugins.InterceptorException;
+import org.restheart.plugins.PluginRecord;
+import org.restheart.plugins.PluginsRegistry;
+import org.restheart.plugins.PluginsRegistryImpl;
+import org.restheart.plugins.WildcardInterceptor;
+import org.restheart.utils.HttpStatus;
+import org.restheart.utils.LambdaUtils;
+import org.restheart.utils.PluginUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.undertow.server.HttpServerExchange;
+
+/**
+ * Runs the enabled {@link WildcardInterceptor}s for a given {@link InterceptPoint}
+ * on the SSE handshake pipeline (see {@code PluginsRegistryImpl#plugSseService}).
+ *
+ * <p>{@code SseService} is a {@code Plugin}, not an {@code ExchangeTypeResolver}: an
+ * SSE service declares no request/response types, so the type-equality check that
+ * {@code RequestInterceptorsExecutor} uses to admit interceptors on the SERVICE
+ * pipeline has nothing to compare against on this path, and the PROXY-pipeline
+ * fallback only admits {@code ByteArrayProxyRequest}/{@code ByteArrayProxyResponse}
+ * typed interceptors. {@code WildcardInterceptor} is the only interceptor category
+ * that is meaningful here, so this executor admits only those, deliberately mirroring
+ * the shape of {@link BeforeExchangeInitInterceptorsExecutor} (which solves the
+ * analogous problem for {@code REQUEST_BEFORE_EXCHANGE_INIT}) rather than reusing
+ * {@link RequestInterceptorsExecutor}, which several other handlers key off the
+ * SERVICE/PROXY {@code PipelineInfo} type and must stay untouched.
+ *
+ * <p>Interceptors are invoked with {@code SseHandshakeRequest}/{@code SseHandshakeResponse},
+ * a minimal concrete {@code ServiceRequest}/{@code ServiceResponse} pair that exposes path,
+ * headers, query parameters and the authenticated account, and (on the response side) a
+ * working {@code setInError}.
+ *
+ * <p>Denial only takes effect at {@code REQUEST_AFTER_AUTH}, mirroring
+ * {@link RequestInterceptorsExecutor}: denying at {@code REQUEST_BEFORE_AUTH} would let an
+ * unauthenticated request learn something about the endpoint from the error response.
+ *
+ * @author Maurizio Turatti {@literal <maurizio@softinstigate.com>}
+ * @see WildcardInterceptor
+ * @see SseHandshakeRequest
+ * @see SseHandshakeResponse
+ */
+public class SseWildcardInterceptorsExecutor extends PipelinedHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SseWildcardInterceptorsExecutor.class);
+
+    private final InterceptPoint interceptPoint;
+
+    private final List<WildcardInterceptor> wildcardInterceptors;
+
+    /**
+     * Creates a new executor with no next handler.
+     *
+     * @param interceptPoint the intercept point this executor runs interceptors for
+     */
+    public SseWildcardInterceptorsExecutor(InterceptPoint interceptPoint) {
+        this(null, interceptPoint);
+    }
+
+    /**
+     * Creates a new executor.
+     *
+     * @param next the next handler in the pipeline
+     * @param interceptPoint the intercept point this executor runs interceptors for
+     */
+    public SseWildcardInterceptorsExecutor(PipelinedHandler next, InterceptPoint interceptPoint) {
+        super(next);
+        this.interceptPoint = interceptPoint;
+
+        PluginsRegistry pluginsRegistry = PluginsRegistryImpl.getInstance();
+
+        this.wildcardInterceptors = pluginsRegistry.getInterceptors().stream()
+                .filter(PluginRecord::isEnabled)
+                .map(PluginRecord::getInstance)
+                .filter(i -> i instanceof WildcardInterceptor)
+                .filter(i -> PluginUtils.interceptPoint(i) == interceptPoint)
+                .map(i -> (WildcardInterceptor) i)
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        if (this.wildcardInterceptors.isEmpty()) {
+            LOGGER.debug("{} SSE WILDCARD INTERCEPTORS: none registered", interceptPoint);
+            next(exchange);
+            return;
+        }
+
+        var request = SseHandshakeRequest.of(exchange);
+        var response = SseHandshakeResponse.of(exchange);
+
+        RequestPhaseContext.setPhase(Phase.PHASE_START);
+        LOGGER.debug("{} SSE WILDCARD INTERCEPTORS for {} {}", interceptPoint, exchange.getRequestMethod(), exchange.getRequestPath());
+
+        List<WildcardInterceptor> resolvedInterceptors = null;
+        for (var ri : this.wildcardInterceptors) {
+            try {
+                if (ri.resolve(request, response)) {
+                    if (resolvedInterceptors == null) {
+                        resolvedInterceptors = new ArrayList<>(this.wildcardInterceptors.size());
+                    }
+                    resolvedInterceptors.add(ri);
+                }
+            } catch (Exception ex) {
+                LOGGER.warn("Error resolving interceptor {} for {} on intercept point {}", ri.getClass().getSimpleName(), exchange.getRequestPath(), interceptPoint, ex);
+
+                Exchange.setInError(exchange);
+                LambdaUtils.throwsSneakyException(new InterceptorException("Error resolving interceptor " + ri.getClass().getSimpleName(), ex));
+            }
+        }
+        if (resolvedInterceptors == null) {
+            resolvedInterceptors = List.of();
+        }
+
+        RequestPhaseContext.setPhase(Phase.INFO);
+        LOGGER.debug("Found {} SSE wildcard interceptors", resolvedInterceptors.size());
+
+        for (var ri : resolvedInterceptors) {
+            try {
+                RequestPhaseContext.setPhase(Phase.ITEM);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("{} (priority: {})", PluginUtils.name(ri), PluginUtils.priority(ri));
+                }
+
+                ri.handle(request, response);
+            } catch (Exception ex) {
+                RequestPhaseContext.setPhase(Phase.SUBITEM);
+                LOGGER.error("✗ FAILED: {}", ex.getMessage());
+
+                Exchange.setInError(exchange);
+                LambdaUtils.throwsSneakyException(new InterceptorException("Error executing interceptor " + ri.getClass().getSimpleName(), ex));
+            }
+        }
+
+        RequestPhaseContext.setPhase(Phase.PHASE_END);
+        LOGGER.debug("{} SSE WILDCARD INTERCEPTORS COMPLETED", interceptPoint);
+        RequestPhaseContext.reset();
+
+        // Denial only takes effect after auth, mirroring RequestInterceptorsExecutor:
+        // denying before auth would let an unauthenticated client learn something
+        // about the endpoint from the error response.
+        if (this.interceptPoint == InterceptPoint.REQUEST_AFTER_AUTH && Exchange.isInError(exchange)) {
+            if (response.getStatusCode() < 0) {
+                response.setStatusCode(HttpStatus.SC_BAD_REQUEST);
+            }
+
+            exchange.setStatusCode(response.getStatusCode());
+
+            var content = response.readContent();
+            if (content != null) {
+                exchange.getResponseSender().send(content);
+            } else {
+                exchange.endExchange();
+            }
+        } else {
+            next(exchange);
+        }
+    }
+}

--- a/core/src/main/java/org/restheart/handlers/SseWildcardInterceptorsExecutor.java
+++ b/core/src/main/java/org/restheart/handlers/SseWildcardInterceptorsExecutor.java
@@ -1,3 +1,24 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart
+ * %%
+ * Copyright (C) 2014 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+
 package org.restheart.handlers;
 
 import java.util.ArrayList;
@@ -22,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.undertow.server.HttpServerExchange;
+import io.undertow.util.AttachmentKey;
 
 /**
  * Runs the enabled {@link WildcardInterceptor}s for a given {@link InterceptPoint}
@@ -44,9 +66,19 @@ import io.undertow.server.HttpServerExchange;
  * headers, query parameters and the authenticated account, and (on the response side) a
  * working {@code setInError}.
  *
- * <p>Denial only takes effect at {@code REQUEST_AFTER_AUTH}, mirroring
- * {@link RequestInterceptorsExecutor}: denying at {@code REQUEST_BEFORE_AUTH} would let an
- * unauthenticated request learn something about the endpoint from the error response.
+ * <p>The SSE pipeline runs this executor twice for the same exchange: once at
+ * {@code REQUEST_BEFORE_AUTH}, once at {@code REQUEST_AFTER_AUTH}. A denial raised via
+ * {@code response.setInError(...)} at {@code REQUEST_BEFORE_AUTH} is <strong>deferred, not
+ * ignored</strong>, mirroring {@link RequestInterceptorsExecutor} (see the comment above its
+ * {@code REQUEST_AFTER_AUTH} check): sending the error response before authentication would
+ * let an unauthenticated client learn something about the endpoint. The two invocations share
+ * a single {@code SseHandshakeRequest}/{@code SseHandshakeResponse} pair for the exchange,
+ * attached under an {@link AttachmentKey} owned by this class (deliberately not
+ * {@code ServiceRequest}/{@code ServiceResponse}'s own {@code REQUEST_KEY}/{@code RESPONSE_KEY},
+ * which other handlers on this pipeline rely on staying unpopulated): whichever invocation runs
+ * first creates the pair, the other reuses it. So a status code and body set on a
+ * {@code REQUEST_BEFORE_AUTH} denial are still the ones sent once {@code REQUEST_AFTER_AUTH}
+ * observes the exchange in error.
  *
  * @author Maurizio Turatti {@literal <maurizio@softinstigate.com>}
  * @see WildcardInterceptor
@@ -55,6 +87,22 @@ import io.undertow.server.HttpServerExchange;
  */
 public class SseWildcardInterceptorsExecutor extends PipelinedHandler {
     private static final Logger LOGGER = LoggerFactory.getLogger(SseWildcardInterceptorsExecutor.class);
+
+    /**
+     * Attachment key under which the {@code SseHandshakeRequest} shared by the
+     * {@code REQUEST_BEFORE_AUTH} and {@code REQUEST_AFTER_AUTH} invocations of this executor
+     * is stored, so a denial raised before auth carries its request context to the invocation
+     * that sends it.
+     */
+    private static final AttachmentKey<SseHandshakeRequest> SSE_HANDSHAKE_REQUEST_KEY = AttachmentKey.create(SseHandshakeRequest.class);
+
+    /**
+     * Attachment key under which the {@code SseHandshakeResponse} shared by the
+     * {@code REQUEST_BEFORE_AUTH} and {@code REQUEST_AFTER_AUTH} invocations of this executor
+     * is stored, so a denial raised before auth carries its status code and body to the
+     * invocation that sends it.
+     */
+    private static final AttachmentKey<SseHandshakeResponse> SSE_HANDSHAKE_RESPONSE_KEY = AttachmentKey.create(SseHandshakeResponse.class);
 
     private final InterceptPoint interceptPoint;
 
@@ -101,8 +149,17 @@ public class SseWildcardInterceptorsExecutor extends PipelinedHandler {
             return;
         }
 
-        var request = SseHandshakeRequest.of(exchange);
-        var response = SseHandshakeResponse.of(exchange);
+        var request = exchange.getAttachment(SSE_HANDSHAKE_REQUEST_KEY);
+        if (request == null) {
+            request = SseHandshakeRequest.of(exchange);
+            exchange.putAttachment(SSE_HANDSHAKE_REQUEST_KEY, request);
+        }
+
+        var response = exchange.getAttachment(SSE_HANDSHAKE_RESPONSE_KEY);
+        if (response == null) {
+            response = SseHandshakeResponse.of(exchange);
+            exchange.putAttachment(SSE_HANDSHAKE_RESPONSE_KEY, response);
+        }
 
         RequestPhaseContext.setPhase(Phase.PHASE_START);
         LOGGER.debug("{} SSE WILDCARD INTERCEPTORS for {} {}", interceptPoint, exchange.getRequestMethod(), exchange.getRequestPath());

--- a/core/src/main/java/org/restheart/handlers/SseWildcardInterceptorsExecutor.java
+++ b/core/src/main/java/org/restheart/handlers/SseWildcardInterceptorsExecutor.java
@@ -143,12 +143,6 @@ public class SseWildcardInterceptorsExecutor extends PipelinedHandler {
      */
     @Override
     public void handleRequest(HttpServerExchange exchange) throws Exception {
-        if (this.wildcardInterceptors.isEmpty()) {
-            LOGGER.debug("{} SSE WILDCARD INTERCEPTORS: none registered", interceptPoint);
-            next(exchange);
-            return;
-        }
-
         var request = exchange.getAttachment(SSE_HANDSHAKE_REQUEST_KEY);
         if (request == null) {
             request = SseHandshakeRequest.of(exchange);
@@ -161,56 +155,67 @@ public class SseWildcardInterceptorsExecutor extends PipelinedHandler {
             exchange.putAttachment(SSE_HANDSHAKE_RESPONSE_KEY, response);
         }
 
-        RequestPhaseContext.setPhase(Phase.PHASE_START);
-        LOGGER.debug("{} SSE WILDCARD INTERCEPTORS for {} {}", interceptPoint, exchange.getRequestMethod(), exchange.getRequestPath());
+        if (this.wildcardInterceptors.isEmpty()) {
+            // nothing of this executor's own to resolve/run, but a pending denial from the
+            // other invocation of this executor on the same exchange (see the shared
+            // request/response pair above) must still reach the terminal check below:
+            // an empty list here must never bypass it.
+            LOGGER.debug("{} SSE WILDCARD INTERCEPTORS: none registered", interceptPoint);
+        } else {
+            RequestPhaseContext.setPhase(Phase.PHASE_START);
+            LOGGER.debug("{} SSE WILDCARD INTERCEPTORS for {} {}", interceptPoint, exchange.getRequestMethod(), exchange.getRequestPath());
 
-        List<WildcardInterceptor> resolvedInterceptors = null;
-        for (var ri : this.wildcardInterceptors) {
-            try {
-                if (ri.resolve(request, response)) {
-                    if (resolvedInterceptors == null) {
-                        resolvedInterceptors = new ArrayList<>(this.wildcardInterceptors.size());
+            List<WildcardInterceptor> resolvedInterceptors = null;
+            for (var ri : this.wildcardInterceptors) {
+                try {
+                    if (ri.resolve(request, response)) {
+                        if (resolvedInterceptors == null) {
+                            resolvedInterceptors = new ArrayList<>(this.wildcardInterceptors.size());
+                        }
+                        resolvedInterceptors.add(ri);
                     }
-                    resolvedInterceptors.add(ri);
+                } catch (Exception ex) {
+                    LOGGER.warn("Error resolving interceptor {} for {} on intercept point {}", ri.getClass().getSimpleName(), exchange.getRequestPath(), interceptPoint, ex);
+
+                    Exchange.setInError(exchange);
+                    LambdaUtils.throwsSneakyException(new InterceptorException("Error resolving interceptor " + ri.getClass().getSimpleName(), ex));
                 }
-            } catch (Exception ex) {
-                LOGGER.warn("Error resolving interceptor {} for {} on intercept point {}", ri.getClass().getSimpleName(), exchange.getRequestPath(), interceptPoint, ex);
-
-                Exchange.setInError(exchange);
-                LambdaUtils.throwsSneakyException(new InterceptorException("Error resolving interceptor " + ri.getClass().getSimpleName(), ex));
             }
-        }
-        if (resolvedInterceptors == null) {
-            resolvedInterceptors = List.of();
-        }
+            if (resolvedInterceptors == null) {
+                resolvedInterceptors = List.of();
+            }
 
-        RequestPhaseContext.setPhase(Phase.INFO);
-        LOGGER.debug("Found {} SSE wildcard interceptors", resolvedInterceptors.size());
+            RequestPhaseContext.setPhase(Phase.INFO);
+            LOGGER.debug("Found {} SSE wildcard interceptors", resolvedInterceptors.size());
 
-        for (var ri : resolvedInterceptors) {
-            try {
-                RequestPhaseContext.setPhase(Phase.ITEM);
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("{} (priority: {})", PluginUtils.name(ri), PluginUtils.priority(ri));
+            for (var ri : resolvedInterceptors) {
+                try {
+                    RequestPhaseContext.setPhase(Phase.ITEM);
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("{} (priority: {})", PluginUtils.name(ri), PluginUtils.priority(ri));
+                    }
+
+                    ri.handle(request, response);
+                } catch (Exception ex) {
+                    RequestPhaseContext.setPhase(Phase.SUBITEM);
+                    LOGGER.error("✗ FAILED: {}", ex.getMessage());
+
+                    Exchange.setInError(exchange);
+                    LambdaUtils.throwsSneakyException(new InterceptorException("Error executing interceptor " + ri.getClass().getSimpleName(), ex));
                 }
-
-                ri.handle(request, response);
-            } catch (Exception ex) {
-                RequestPhaseContext.setPhase(Phase.SUBITEM);
-                LOGGER.error("✗ FAILED: {}", ex.getMessage());
-
-                Exchange.setInError(exchange);
-                LambdaUtils.throwsSneakyException(new InterceptorException("Error executing interceptor " + ri.getClass().getSimpleName(), ex));
             }
-        }
 
-        RequestPhaseContext.setPhase(Phase.PHASE_END);
-        LOGGER.debug("{} SSE WILDCARD INTERCEPTORS COMPLETED", interceptPoint);
-        RequestPhaseContext.reset();
+            RequestPhaseContext.setPhase(Phase.PHASE_END);
+            LOGGER.debug("{} SSE WILDCARD INTERCEPTORS COMPLETED", interceptPoint);
+            RequestPhaseContext.reset();
+        }
 
         // Denial only takes effect after auth, mirroring RequestInterceptorsExecutor:
         // denying before auth would let an unauthenticated client learn something
-        // about the endpoint from the error response.
+        // about the endpoint from the error response. Reached unconditionally (not just
+        // when this executor has interceptors of its own): a denial raised by the
+        // REQUEST_BEFORE_AUTH invocation of this executor must still be observed and sent
+        // here even if zero WildcardInterceptors are registered for REQUEST_AFTER_AUTH.
         if (this.interceptPoint == InterceptPoint.REQUEST_AFTER_AUTH && Exchange.isInError(exchange)) {
             if (response.getStatusCode() < 0) {
                 response.setStatusCode(HttpStatus.SC_BAD_REQUEST);

--- a/core/src/main/java/org/restheart/plugins/PluginsRegistryImpl.java
+++ b/core/src/main/java/org/restheart/plugins/PluginsRegistryImpl.java
@@ -55,6 +55,7 @@ import org.restheart.handlers.RequestLogger;
 import org.restheart.handlers.ResponseInterceptorsExecutor;
 import org.restheart.handlers.ResponseSender;
 import org.restheart.handlers.ServiceExchangeInitializer;
+import org.restheart.handlers.SseWildcardInterceptorsExecutor;
 import org.restheart.handlers.TracingInstrumentationHandler;
 import org.restheart.handlers.WorkingThreadsPoolDispatcher;
 import org.restheart.handlers.injectors.PipelineInfoInjector;
@@ -573,9 +574,22 @@ public class PluginsRegistryImpl implements PluginsRegistry {
      * Plugs an SSE service into the root handler binding it to the specified path.
      *
      * <p>Builds a lightweight pipeline: ErrorHandler → PipelineInfoInjector →
-     * TracingInstrumentationHandler → RequestLogger → SecurityHandler →
-     * ServerSentEventHandler. The SSE connection lifecycle (keep-alive, close tasks,
-     * event sending) is entirely managed by the plugin's {@code onConnect} method.
+     * TracingInstrumentationHandler → RequestLogger → SseWildcardInterceptorsExecutor
+     * (REQUEST_BEFORE_AUTH) → SecurityHandler → SseWildcardInterceptorsExecutor
+     * (REQUEST_AFTER_AUTH) → ServerSentEventHandler. The SSE connection lifecycle
+     * (keep-alive, close tasks, event sending) is entirely managed by the plugin's
+     * {@code onConnect} method.
+     *
+     * <p>{@code SseService} is a {@code Plugin}, not an {@code ExchangeTypeResolver}, so it
+     * declares no request/response types: only {@link WildcardInterceptor}s (not typed
+     * interceptors) can meaningfully run on this pipeline. See
+     * {@link SseWildcardInterceptorsExecutor} for why this is a dedicated executor rather
+     * than {@link RequestInterceptorsExecutor}, and why this pipeline does not include a
+     * {@code QueryStringRebuilder}: {@code WildcardInterceptor}s mutate query parameters via
+     * {@code Request#getQueryParameters()}, which is backed by the same live map that
+     * Undertow's {@code ServerSentEventConnection#getQueryParameters()} exposes to the SSE
+     * service, so any such mutation is visible downstream without rebuilding the raw query
+     * string.
      *
      * @param srv     the SSE service plugin record to plug
      * @param uri     the URI path to bind the service to
@@ -622,7 +636,9 @@ public class PluginsRegistryImpl implements PluginsRegistry {
                 new PipelineInfoInjector(),
                 new TracingInstrumentationHandler(),
                 new RequestLogger(),
+                new SseWildcardInterceptorsExecutor(REQUEST_BEFORE_AUTH),
                 securityHandler,
+                new SseWildcardInterceptorsExecutor(REQUEST_AFTER_AUTH),
                 PipelinedWrappingHandler.wrap(sseHandler)
         );
 

--- a/core/src/test/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/test/java/io/undertow/server/HttpServerExchange.java
@@ -245,8 +245,24 @@ public class HttpServerExchange extends AbstractAttachable {
         }
     }
 
+    private SecurityContext securityContext;
+
     public SecurityContext getSecurityContext() {
-        return null;
+        return securityContext;
+    }
+
+    public void setSecurityContext(SecurityContext securityContext) {
+        this.securityContext = securityContext;
+    }
+
+    private final String requestId = "test-request-id";
+
+    /**
+     * @return a fixed, test-only request id (the real Undertow implementation
+     *         generates a unique one per exchange; this fake does not need to)
+     */
+    public String getRequestId() {
+        return requestId;
     }
 
     /**

--- a/core/src/test/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/test/java/io/undertow/server/HttpServerExchange.java
@@ -20,12 +20,17 @@
  */
 package io.undertow.server;
 
+import io.undertow.io.IoCallback;
+import io.undertow.io.Sender;
 import io.undertow.security.api.SecurityContext;
 import io.undertow.util.AbstractAttachable;
 import io.undertow.util.HeaderMap;
 import io.undertow.util.HttpString;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
@@ -152,6 +157,92 @@ public class HttpServerExchange extends AbstractAttachable {
 
     public HeaderMap getRequestHeaders() {
         return null;
+    }
+
+    private HeaderMap responseHeaders;
+
+    /**
+     * @return the response headers, created lazily on first access
+     */
+    public HeaderMap getResponseHeaders() {
+        if (responseHeaders == null) {
+            responseHeaders = new HeaderMap();
+        }
+        return responseHeaders;
+    }
+
+    private final RecordingSender responseSender = new RecordingSender();
+
+    /**
+     * @return a {@link Sender} that records the last content passed to
+     *         {@code send(String)}, retrievable via {@link #getSentContent()}
+     */
+    public Sender getResponseSender() {
+        return responseSender;
+    }
+
+    /**
+     * @return the content last passed to {@code getResponseSender().send(String)},
+     *         or {@code null} if nothing was sent
+     */
+    public String getSentContent() {
+        return responseSender.sentContent;
+    }
+
+    /**
+     * Minimal {@link Sender} fake that only records String content sent via
+     * {@code send(String)}/{@code send(String, Charset)}; every other method is a no-op.
+     */
+    private static class RecordingSender implements Sender {
+        private String sentContent;
+
+        @Override
+        public void send(ByteBuffer buffer, IoCallback callback) {
+        }
+
+        @Override
+        public void send(ByteBuffer[] buffer, IoCallback callback) {
+        }
+
+        @Override
+        public void send(ByteBuffer buffer) {
+        }
+
+        @Override
+        public void send(ByteBuffer[] buffer) {
+        }
+
+        @Override
+        public void send(String data, IoCallback callback) {
+            this.sentContent = data;
+        }
+
+        @Override
+        public void send(String data, Charset charset, IoCallback callback) {
+            this.sentContent = data;
+        }
+
+        @Override
+        public void send(String data) {
+            this.sentContent = data;
+        }
+
+        @Override
+        public void send(String data, Charset charset) {
+            this.sentContent = data;
+        }
+
+        @Override
+        public void transferFrom(FileChannel channel, IoCallback callback) {
+        }
+
+        @Override
+        public void close(IoCallback callback) {
+        }
+
+        @Override
+        public void close() {
+        }
     }
 
     public SecurityContext getSecurityContext() {

--- a/core/src/test/java/org/restheart/handlers/SseWildcardInterceptorsExecutorTest.java
+++ b/core/src/test/java/org/restheart/handlers/SseWildcardInterceptorsExecutorTest.java
@@ -1,0 +1,280 @@
+package org.restheart.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.restheart.exchange.Exchange;
+import org.restheart.exchange.ServiceRequest;
+import org.restheart.exchange.ServiceResponse;
+import org.restheart.plugins.Interceptor;
+import org.restheart.plugins.InterceptPoint;
+import org.restheart.plugins.PluginRecord;
+import org.restheart.plugins.PluginsRegistryImpl;
+import org.restheart.plugins.RegisterPlugin;
+import org.restheart.plugins.WildcardInterceptor;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+
+/**
+ * Proves that {@link SseWildcardInterceptorsExecutor} wires {@link WildcardInterceptor}s
+ * into the SSE handshake pipeline: it invokes them in the right place, honors {@code resolve()},
+ * excludes non-wildcard interceptors, and lets a {@code REQUEST_AFTER_AUTH} denial short-circuit
+ * the pipeline while a {@code REQUEST_BEFORE_AUTH} one does not.
+ *
+ * <p>{@code PluginsRegistryImpl} is a process-wide singleton reached via a static
+ * {@code getInstance()} call, and {@link SseWildcardInterceptorsExecutor} reads it directly in
+ * its constructor (mirroring the existing {@code BeforeExchangeInitInterceptorsExecutor}, which
+ * has no unit test of its own). There is no seam to inject a fake registry, so these tests use
+ * {@code mockStatic(PluginsRegistryImpl.class)} to substitute a mock registry for the duration of
+ * each test, rather than mutating the real singleton (which is shared across the whole JVM).
+ *
+ * <p>{@code HttpServerExchange} is exercised via the module's existing test-only shadow class at
+ * {@code io.undertow.server.HttpServerExchange} (same fully-qualified name as Undertow's real,
+ * final class; this test source root takes precedence over the dependency jar for that name, both
+ * at compile time and at test runtime, so production code under test binds to the very same fake
+ * instance this test constructs). It was extended here with {@code getResponseHeaders()} and a
+ * recording {@code getResponseSender()}, the two methods this executor needs that the pre-existing
+ * shadow class did not yet provide.
+ *
+ * @author Maurizio Turatti {@literal <maurizio@softinstigate.com>}
+ */
+public class SseWildcardInterceptorsExecutorTest {
+
+    // -----------------------------------------------------------------------
+    // Test fixtures
+    // -----------------------------------------------------------------------
+
+    @RegisterPlugin(name = "afterAuthWildcard", interceptPoint = InterceptPoint.REQUEST_AFTER_AUTH, description = "test")
+    static class AfterAuthWildcardInterceptor implements WildcardInterceptor {
+        private final List<String> calls;
+        private final boolean resolves;
+        private final Integer denyCode;
+
+        AfterAuthWildcardInterceptor(List<String> calls, boolean resolves, Integer denyCode) {
+            this.calls = calls;
+            this.resolves = resolves;
+            this.denyCode = denyCode;
+        }
+
+        @Override
+        public boolean resolve(ServiceRequest<?> request, ServiceResponse<?> response) {
+            return resolves;
+        }
+
+        @Override
+        public void handle(ServiceRequest<?> request, ServiceResponse<?> response) {
+            calls.add("afterAuthWildcard");
+            if (denyCode != null) {
+                response.setInError(denyCode, "denied by test interceptor", null);
+            }
+        }
+    }
+
+    @RegisterPlugin(name = "beforeAuthWildcard", interceptPoint = InterceptPoint.REQUEST_BEFORE_AUTH, description = "test")
+    static class BeforeAuthWildcardInterceptor implements WildcardInterceptor {
+        private final List<String> calls;
+        private final Integer denyCode;
+
+        BeforeAuthWildcardInterceptor(List<String> calls, Integer denyCode) {
+            this.calls = calls;
+            this.denyCode = denyCode;
+        }
+
+        @Override
+        public boolean resolve(ServiceRequest<?> request, ServiceResponse<?> response) {
+            return true;
+        }
+
+        @Override
+        public void handle(ServiceRequest<?> request, ServiceResponse<?> response) {
+            calls.add("beforeAuthWildcard");
+            if (denyCode != null) {
+                response.setInError(denyCode, "denied before auth", null);
+            }
+        }
+    }
+
+    @RegisterPlugin(name = "nonWildcard", interceptPoint = InterceptPoint.REQUEST_AFTER_AUTH, description = "must never run on the SSE path")
+    static class NonWildcardInterceptor implements Interceptor<ServiceRequest<?>, ServiceResponse<?>> {
+        private final List<String> calls;
+
+        NonWildcardInterceptor(List<String> calls) {
+            this.calls = calls;
+        }
+
+        @Override
+        public boolean resolve(ServiceRequest<?> request, ServiceResponse<?> response) {
+            return true;
+        }
+
+        @Override
+        public void handle(ServiceRequest<?> request, ServiceResponse<?> response) {
+            calls.add("nonWildcard");
+        }
+    }
+
+    /** Records invocation order; stands in for the next handler in the pipeline (e.g. the security handler). */
+    static class RecordingHandler extends PipelinedHandler {
+        private final List<String> calls;
+        private final String label;
+
+        RecordingHandler(List<String> calls, String label) {
+            super(null);
+            this.calls = calls;
+            this.label = label;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            calls.add(label);
+            next(exchange);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    private static HttpServerExchange fakeExchange() {
+        var exchange = new HttpServerExchange();
+        exchange.setRequestPath("/sse/clock");
+        exchange.setRequestMethod(new HttpString("GET"));
+        return exchange;
+    }
+
+    private static PluginRecord<Interceptor<?, ?>> record(Interceptor<?, ?> instance) {
+        return new PluginRecord<>(
+                instance.getClass().getSimpleName(),
+                "test interceptor",
+                false,
+                true, // enabledByDefault
+                instance.getClass().getName(),
+                instance,
+                null // confArgs
+        );
+    }
+
+    /**
+     * Substitutes {@code PluginsRegistryImpl.getInstance()} with a mock reporting the given
+     * interceptors, for the lifetime of the returned {@link AutoCloseable}.
+     */
+    private static AutoCloseable registryReturning(Set<PluginRecord<Interceptor<?, ?>>> interceptors) {
+        var registryMock = mock(PluginsRegistryImpl.class);
+        when(registryMock.getInterceptors()).thenReturn(interceptors);
+
+        var registryStatic = mockStatic(PluginsRegistryImpl.class);
+        registryStatic.when(PluginsRegistryImpl::getInstance).thenReturn(registryMock);
+        return registryStatic;
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    @Test
+    public void afterAuthWildcardInterceptorIsInvokedAndDenialTakesEffect() throws Exception {
+        var calls = new ArrayList<String>();
+        var denying = new AfterAuthWildcardInterceptor(calls, true, 403);
+
+        try (var registryStatic = registryReturning(Set.of(record(denying)))) {
+            var next = new RecordingHandler(calls, "next");
+            var executor = new SseWildcardInterceptorsExecutor(next, InterceptPoint.REQUEST_AFTER_AUTH);
+            var exchange = fakeExchange();
+
+            executor.handleRequest(exchange);
+
+            assertEquals(List.of("afterAuthWildcard"), calls,
+                    "the interceptor must have run, and the pipeline must stop there (next must not run)");
+            assertTrue(Exchange.isInError(exchange), "the exchange must be flagged in error");
+            assertEquals(403, exchange.getStatusCode(), "the denial status code must be written to the exchange");
+            assertTrue(exchange.getSentContent() != null && exchange.getSentContent().contains("denied by test interceptor"),
+                    "the denial body must be sent to the client");
+        }
+    }
+
+    @Test
+    public void beforeAuthWildcardInterceptorRunsBeforeTheNextHandlerAndDenialHasNoEffect() throws Exception {
+        var calls = new ArrayList<String>();
+        // even though this interceptor calls setInError, REQUEST_BEFORE_AUTH denial must not
+        // short-circuit the pipeline (mirrors RequestInterceptorsExecutor: denying pre-auth would
+        // let an unauthenticated client learn something about the endpoint from the error body).
+        var beforeAuth = new BeforeAuthWildcardInterceptor(calls, 403);
+
+        try (var registryStatic = registryReturning(Set.of(record(beforeAuth)))) {
+            var securityHandlerStandIn = new RecordingHandler(calls, "securityHandler");
+            var executor = new SseWildcardInterceptorsExecutor(securityHandlerStandIn, InterceptPoint.REQUEST_BEFORE_AUTH);
+            var exchange = fakeExchange();
+
+            executor.handleRequest(exchange);
+
+            assertEquals(List.of("beforeAuthWildcard", "securityHandler"), calls,
+                    "the interceptor must run, then hand off to the next handler (the security handler)");
+        }
+    }
+
+    @Test
+    public void interceptorWhoseResolveReturnsFalseIsNotInvoked() throws Exception {
+        var calls = new ArrayList<String>();
+        var unresolved = new AfterAuthWildcardInterceptor(calls, false, null);
+
+        try (var registryStatic = registryReturning(Set.of(record(unresolved)))) {
+            var next = new RecordingHandler(calls, "next");
+            var executor = new SseWildcardInterceptorsExecutor(next, InterceptPoint.REQUEST_AFTER_AUTH);
+            var exchange = fakeExchange();
+
+            executor.handleRequest(exchange);
+
+            assertFalse(calls.contains("afterAuthWildcard"), "an interceptor whose resolve() returns false must not be handled");
+            assertEquals(List.of("next"), calls, "the pipeline must still proceed to the next handler");
+        }
+    }
+
+    @Test
+    public void nonWildcardInterceptorIsNotInvokedOnTheSsePath() throws Exception {
+        var calls = new ArrayList<String>();
+        var wildcard = new AfterAuthWildcardInterceptor(calls, true, null);
+        var plain = new NonWildcardInterceptor(calls);
+
+        var interceptors = new LinkedHashSet<PluginRecord<Interceptor<?, ?>>>();
+        interceptors.add(record(wildcard));
+        interceptors.add(record(plain));
+
+        try (var registryStatic = registryReturning(interceptors)) {
+            var next = new RecordingHandler(calls, "next");
+            var executor = new SseWildcardInterceptorsExecutor(next, InterceptPoint.REQUEST_AFTER_AUTH);
+            var exchange = fakeExchange();
+
+            executor.handleRequest(exchange);
+
+            assertFalse(calls.contains("nonWildcard"),
+                    "a plain Interceptor<ServiceRequest<?>, ServiceResponse<?>> must be excluded from the SSE path");
+            assertEquals(List.of("afterAuthWildcard", "next"), calls,
+                    "only the WildcardInterceptor must run, then the pipeline proceeds");
+        }
+    }
+
+    @Test
+    public void noWildcardInterceptorsRegisteredForcesFastPathToNext() throws Exception {
+        try (var registryStatic = registryReturning(Set.of())) {
+            var calls = new ArrayList<String>();
+            var next = new RecordingHandler(calls, "next");
+            var executor = new SseWildcardInterceptorsExecutor(next, InterceptPoint.REQUEST_AFTER_AUTH);
+            var exchange = fakeExchange();
+
+            executor.handleRequest(exchange);
+
+            assertEquals(List.of("next"), calls);
+        }
+    }
+}

--- a/core/src/test/java/org/restheart/handlers/SseWildcardInterceptorsExecutorTest.java
+++ b/core/src/test/java/org/restheart/handlers/SseWildcardInterceptorsExecutorTest.java
@@ -1,3 +1,24 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart
+ * %%
+ * Copyright (C) 2014 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+
 package org.restheart.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -24,13 +45,16 @@ import org.restheart.plugins.RegisterPlugin;
 import org.restheart.plugins.WildcardInterceptor;
 
 import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
 
 /**
  * Proves that {@link SseWildcardInterceptorsExecutor} wires {@link WildcardInterceptor}s
  * into the SSE handshake pipeline: it invokes them in the right place, honors {@code resolve()},
- * excludes non-wildcard interceptors, and lets a {@code REQUEST_AFTER_AUTH} denial short-circuit
- * the pipeline while a {@code REQUEST_BEFORE_AUTH} one does not.
+ * excludes non-wildcard interceptors, lets a {@code REQUEST_AFTER_AUTH} denial short-circuit the
+ * pipeline, and defers (rather than drops) a {@code REQUEST_BEFORE_AUTH} denial until the
+ * {@code REQUEST_AFTER_AUTH} invocation, at which point it is sent with its original status code
+ * and body.
  *
  * <p>{@code PluginsRegistryImpl} is a process-wide singleton reached via a static
  * {@code getInstance()} call, and {@link SseWildcardInterceptorsExecutor} reads it directly in
@@ -200,15 +224,21 @@ public class SseWildcardInterceptorsExecutorTest {
             assertEquals(403, exchange.getStatusCode(), "the denial status code must be written to the exchange");
             assertTrue(exchange.getSentContent() != null && exchange.getSentContent().contains("denied by test interceptor"),
                     "the denial body must be sent to the client");
+            assertTrue(exchange.getResponseHeaders().getFirst(Headers.CONTENT_TYPE) != null
+                            && exchange.getResponseHeaders().getFirst(Headers.CONTENT_TYPE).contains("application/json"),
+                    "the denial body must be sent with an application/json content type");
         }
     }
 
     @Test
-    public void beforeAuthWildcardInterceptorRunsBeforeTheNextHandlerAndDenialHasNoEffect() throws Exception {
+    public void beforeAuthWildcardInterceptorDenialIsDeferredNotSentImmediately() throws Exception {
         var calls = new ArrayList<String>();
-        // even though this interceptor calls setInError, REQUEST_BEFORE_AUTH denial must not
-        // short-circuit the pipeline (mirrors RequestInterceptorsExecutor: denying pre-auth would
-        // let an unauthenticated client learn something about the endpoint from the error body).
+        // this interceptor calls setInError, but REQUEST_BEFORE_AUTH denial must not
+        // short-circuit the pipeline nor be sent to the client yet (mirrors
+        // RequestInterceptorsExecutor: denying pre-auth would let an unauthenticated client
+        // learn something about the endpoint from the error body). The denial is deferred until
+        // the REQUEST_AFTER_AUTH invocation of this executor, not dropped: see
+        // beforeAuthDenialIsDeferredAndSentAtAfterAuthWithStatusAndBody below.
         var beforeAuth = new BeforeAuthWildcardInterceptor(calls, 403);
 
         try (var registryStatic = registryReturning(Set.of(record(beforeAuth)))) {
@@ -220,6 +250,47 @@ public class SseWildcardInterceptorsExecutorTest {
 
             assertEquals(List.of("beforeAuthWildcard", "securityHandler"), calls,
                     "the interceptor must run, then hand off to the next handler (the security handler)");
+            assertTrue(Exchange.isInError(exchange), "the denial must still flag the exchange as in error, for REQUEST_AFTER_AUTH to observe");
+            assertEquals(0, exchange.getStatusCode(), "the status code must not yet be written to the exchange: nothing has been sent");
+            assertEquals(null, exchange.getSentContent(), "the denial body must not be sent yet: it is deferred to REQUEST_AFTER_AUTH");
+        }
+    }
+
+    @Test
+    public void beforeAuthDenialIsDeferredAndSentAtAfterAuthWithStatusAndBody() throws Exception {
+        var calls = new ArrayList<String>();
+        // denies at REQUEST_BEFORE_AUTH
+        var beforeAuth = new BeforeAuthWildcardInterceptor(calls, 403);
+        // registered at REQUEST_AFTER_AUTH but does not resolve: only its presence matters here,
+        // so that the REQUEST_AFTER_AUTH executor's wildcardInterceptors list is non-empty and it
+        // reaches the in-error check below, exactly as it does in the real pipeline whenever at
+        // least one WildcardInterceptor is registered for REQUEST_AFTER_AUTH
+        var afterAuthNonResolving = new AfterAuthWildcardInterceptor(calls, false, null);
+
+        try (var registryStatic = registryReturning(Set.of(record(beforeAuth), record(afterAuthNonResolving)))) {
+            var nextHandlerStandIn = new RecordingHandler(calls, "next");
+            var afterAuthExecutor = new SseWildcardInterceptorsExecutor(InterceptPoint.REQUEST_AFTER_AUTH);
+            var securityHandlerStandIn = new RecordingHandler(calls, "securityHandler");
+            var beforeAuthExecutor = new SseWildcardInterceptorsExecutor(InterceptPoint.REQUEST_BEFORE_AUTH);
+
+            // wires: beforeAuthExecutor -> securityHandlerStandIn -> afterAuthExecutor -> nextHandlerStandIn
+            var pipeline = PipelinedHandler.pipe(beforeAuthExecutor, securityHandlerStandIn, afterAuthExecutor, nextHandlerStandIn);
+
+            var exchange = fakeExchange();
+
+            pipeline.handleRequest(exchange);
+
+            assertEquals(List.of("beforeAuthWildcard", "securityHandler"), calls,
+                    "the before-auth interceptor and the security handler must run, but the pipeline must stop "
+                            + "at REQUEST_AFTER_AUTH once the deferred denial is observed: the final next handler must never run");
+            assertTrue(Exchange.isInError(exchange), "the exchange must be flagged in error");
+            assertEquals(403, exchange.getStatusCode(),
+                    "the status code set by the REQUEST_BEFORE_AUTH denial must be the one sent after auth");
+            assertTrue(exchange.getSentContent() != null && exchange.getSentContent().contains("denied before auth"),
+                    "the body set by the REQUEST_BEFORE_AUTH denial must be the one sent after auth, not lost");
+            assertTrue(exchange.getResponseHeaders().getFirst(Headers.CONTENT_TYPE) != null
+                            && exchange.getResponseHeaders().getFirst(Headers.CONTENT_TYPE).contains("application/json"),
+                    "the deferred denial body must still be sent with an application/json content type");
         }
     }
 

--- a/core/src/test/java/org/restheart/handlers/SseWildcardInterceptorsExecutorTest.java
+++ b/core/src/test/java/org/restheart/handlers/SseWildcardInterceptorsExecutorTest.java
@@ -261,10 +261,11 @@ public class SseWildcardInterceptorsExecutorTest {
         var calls = new ArrayList<String>();
         // denies at REQUEST_BEFORE_AUTH
         var beforeAuth = new BeforeAuthWildcardInterceptor(calls, 403);
-        // registered at REQUEST_AFTER_AUTH but does not resolve: only its presence matters here,
-        // so that the REQUEST_AFTER_AUTH executor's wildcardInterceptors list is non-empty and it
-        // reaches the in-error check below, exactly as it does in the real pipeline whenever at
-        // least one WildcardInterceptor is registered for REQUEST_AFTER_AUTH
+        // registered at REQUEST_AFTER_AUTH, but does not resolve: covers the "interceptors
+        // present" path, i.e. the REQUEST_AFTER_AUTH executor's wildcardInterceptors list is
+        // non-empty but nothing of its own actually runs. See
+        // beforeAuthDenialIsDeferredAndSentAtAfterAuthWithStatusAndBodyWhenNoAfterAuthInterceptorsRegistered
+        // below for the empty-list case.
         var afterAuthNonResolving = new AfterAuthWildcardInterceptor(calls, false, null);
 
         try (var registryStatic = registryReturning(Set.of(record(beforeAuth), record(afterAuthNonResolving)))) {
@@ -283,6 +284,45 @@ public class SseWildcardInterceptorsExecutorTest {
             assertEquals(List.of("beforeAuthWildcard", "securityHandler"), calls,
                     "the before-auth interceptor and the security handler must run, but the pipeline must stop "
                             + "at REQUEST_AFTER_AUTH once the deferred denial is observed: the final next handler must never run");
+            assertTrue(Exchange.isInError(exchange), "the exchange must be flagged in error");
+            assertEquals(403, exchange.getStatusCode(),
+                    "the status code set by the REQUEST_BEFORE_AUTH denial must be the one sent after auth");
+            assertTrue(exchange.getSentContent() != null && exchange.getSentContent().contains("denied before auth"),
+                    "the body set by the REQUEST_BEFORE_AUTH denial must be the one sent after auth, not lost");
+            assertTrue(exchange.getResponseHeaders().getFirst(Headers.CONTENT_TYPE) != null
+                            && exchange.getResponseHeaders().getFirst(Headers.CONTENT_TYPE).contains("application/json"),
+                    "the deferred denial body must still be sent with an application/json content type");
+        }
+    }
+
+    @Test
+    public void beforeAuthDenialIsDeferredAndSentAtAfterAuthWithStatusAndBodyWhenNoAfterAuthInterceptorsRegistered() throws Exception {
+        var calls = new ArrayList<String>();
+        // denies at REQUEST_BEFORE_AUTH
+        var beforeAuth = new BeforeAuthWildcardInterceptor(calls, 403);
+
+        // negative control: nothing at all is registered for REQUEST_AFTER_AUTH, so that
+        // executor's wildcardInterceptors list is genuinely empty. The pending denial must
+        // still be observed and sent: this must not depend on some other, unrelated
+        // WildcardInterceptor happening to be registered at REQUEST_AFTER_AUTH (in a stock
+        // build, DateHeader/XPoweredBy mask this by always being registered there).
+        try (var registryStatic = registryReturning(Set.of(record(beforeAuth)))) {
+            var nextHandlerStandIn = new RecordingHandler(calls, "next");
+            var afterAuthExecutor = new SseWildcardInterceptorsExecutor(InterceptPoint.REQUEST_AFTER_AUTH);
+            var securityHandlerStandIn = new RecordingHandler(calls, "securityHandler");
+            var beforeAuthExecutor = new SseWildcardInterceptorsExecutor(InterceptPoint.REQUEST_BEFORE_AUTH);
+
+            // wires: beforeAuthExecutor -> securityHandlerStandIn -> afterAuthExecutor -> nextHandlerStandIn
+            var pipeline = PipelinedHandler.pipe(beforeAuthExecutor, securityHandlerStandIn, afterAuthExecutor, nextHandlerStandIn);
+
+            var exchange = fakeExchange();
+
+            pipeline.handleRequest(exchange);
+
+            assertEquals(List.of("beforeAuthWildcard", "securityHandler"), calls,
+                    "the before-auth interceptor and the security handler must run, but the pipeline must stop "
+                            + "at REQUEST_AFTER_AUTH once the deferred denial is observed, even though REQUEST_AFTER_AUTH "
+                            + "has no WildcardInterceptors of its own: the final next handler must never run");
             assertTrue(Exchange.isInError(exchange), "the exchange must be flagged in error");
             assertEquals(403, exchange.getStatusCode(),
                     "the status code set by the REQUEST_BEFORE_AUTH denial must be the one sent after auth");

--- a/core/src/test/java/org/restheart/plugins/PlugSseServiceWiringTest.java
+++ b/core/src/test/java/org/restheart/plugins/PlugSseServiceWiringTest.java
@@ -1,0 +1,290 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart-core
+ * %%
+ * Copyright (C) 2014 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+
+package org.restheart.plugins;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.restheart.Bootstrapper;
+import org.restheart.configuration.Configuration;
+import org.restheart.configuration.Logging;
+import org.restheart.exchange.ServiceRequest;
+import org.restheart.exchange.ServiceResponse;
+import org.restheart.plugins.security.AuthMechanism;
+import org.restheart.plugins.security.Authorizer;
+import org.restheart.plugins.security.TokenManager;
+
+import ch.qos.logback.classic.Level;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.PathHandler;
+import io.undertow.server.handlers.sse.ServerSentEventConnection;
+import io.undertow.util.HttpString;
+import io.undertow.util.PathMatcher;
+
+/**
+ * Proves that {@code PluginsRegistryImpl#plugSseService} actually wires
+ * {@link SseWildcardInterceptorsExecutor} into the pipeline it assembles, rather than merely
+ * proving (as {@code SseWildcardInterceptorsExecutorTest} does) that the executor behaves
+ * correctly in isolation when handed a {@code next} handler directly.
+ *
+ * <p>Unlike {@code SseWildcardInterceptorsExecutorTest}, which substitutes a mock registry via
+ * {@code mockStatic(PluginsRegistryImpl.class)}, this test drives a request through the real,
+ * process-wide {@code PluginsRegistryImpl} singleton: {@code plugSseService} reads it via a bare
+ * {@code PluginsRegistryImpl.getInstance()} call with no seam to inject a fake, so proving the
+ * wiring requires exercising the real singleton end to end. To avoid the real singleton falling
+ * through to {@code PluginsFactory.getInstance()} (a full classpath scan that needs a bootstrapped
+ * {@code Configuration}), the lazily-initialized {@code authMechanisms}/{@code authorizers}/
+ * {@code tokenManager}/{@code interceptors} fields are pre-seeded via reflection before the call
+ * and restored afterwards, so this test does not leak state into others sharing the same JVM fork.
+ *
+ * <p>The {@code io.undertow.server.HttpServerExchange} used here is the module's existing
+ * test-only shadow class (same fully-qualified name as Undertow's real, final class; this test
+ * source root takes precedence over the dependency jar for that name, both at compile time and at
+ * test runtime). It was extended here with {@code getRequestId()} and a working
+ * {@code getSecurityContext()}/{@code setSecurityContext()} pair, the methods the real
+ * {@code TracingInstrumentationHandler} and {@code SecurityInitialHandler} need that the
+ * pre-existing shadow class did not yet provide; {@code Bootstrapper.getConfiguration()} is
+ * mocked to return a {@code Logging} configuration with {@code requests-log-mode: 0} so
+ * {@code RequestLogger} does not attempt to dump the exchange (which would need many more methods
+ * the shadow does not implement, e.g. {@code getSourceAddress()}, {@code getRequestURL()}).
+ *
+ * <p>The request is driven through the exact handler {@code plugSseService} plugs, reached the
+ * same way the framework reaches it in production: via {@code PluginsRegistry#getRootPathHandler()},
+ * resolving the URI through that real Undertow {@code PathHandler}'s own {@code PathMatcher}
+ * (reflectively, since {@code PathHandler#handleRequest} itself needs
+ * {@code getResolvedPath()}/{@code setResolvedPath()}, which the shadow exchange does not
+ * implement) rather than reimplementing the routing decision.
+ *
+ * @author Maurizio Turatti {@literal <maurizio@softinstigate.com>}
+ * @see SseWildcardInterceptorsExecutorTest
+ * @see PluginsRegistryImpl#plugSseService(PluginRecord, String, boolean)
+ */
+public class PlugSseServiceWiringTest {
+
+    private static final String URI = "/__plugSseServiceWiringTest__";
+
+    // -----------------------------------------------------------------------
+    // Test fixtures
+    // -----------------------------------------------------------------------
+
+    @RegisterPlugin(name = "plugSseServiceWiringTestDenier", interceptPoint = InterceptPoint.REQUEST_AFTER_AUTH, description = "test")
+    static class DenyingAfterAuthInterceptor implements WildcardInterceptor {
+        @Override
+        public boolean resolve(ServiceRequest<?> request, ServiceResponse<?> response) {
+            return request.getPath() != null && request.getPath().startsWith(URI);
+        }
+
+        @Override
+        public void handle(ServiceRequest<?> request, ServiceResponse<?> response) {
+            response.setInError(403, "denied by plugSseService wiring test");
+        }
+    }
+
+    static class RecordingSseService implements SseService {
+        private final AtomicBoolean onConnectCalled = new AtomicBoolean(false);
+
+        @Override
+        public void onConnect(ServerSentEventConnection connection, String lastEventId) {
+            onConnectCalled.set(true);
+        }
+
+        boolean wasOnConnectCalled() {
+            return onConnectCalled.get();
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    private static Object getField(Object target, String fieldName) throws ReflectiveOperationException {
+        Field f = target.getClass().getDeclaredField(fieldName);
+        f.setAccessible(true);
+        return f.get(target);
+    }
+
+    private static void setField(Object target, String fieldName, Object value) throws ReflectiveOperationException {
+        Field f = target.getClass().getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    /**
+     * Resolves the {@link HttpHandler} that {@code plugSseService} plugged for the given path, by
+     * reflecting into the root {@link PathHandler}'s own {@code PathMatcher} rather than calling
+     * {@code PathHandler#handleRequest} (which needs exchange methods the test's shadow
+     * {@code HttpServerExchange} does not implement) or reimplementing the routing decision.
+     */
+    @SuppressWarnings("unchecked")
+    private static HttpHandler handlerPluggedFor(PathHandler rootPathHandler, String path) throws ReflectiveOperationException {
+        var pathMatcherField = PathHandler.class.getDeclaredField("pathMatcher");
+        pathMatcherField.setAccessible(true);
+        var pathMatcher = (PathMatcher<HttpHandler>) pathMatcherField.get(rootPathHandler);
+        return pathMatcher.match(path).getValue();
+    }
+
+    private static PluginRecord<Interceptor<?, ?>> interceptorRecord(WildcardInterceptor instance) {
+        return new PluginRecord<>(
+                instance.getClass().getSimpleName(),
+                "test interceptor",
+                false,
+                true, // enabledByDefault
+                instance.getClass().getName(),
+                instance,
+                null // confArgs
+        );
+    }
+
+    private static Configuration configurationWithRequestLoggingDisabled() {
+        // requests-log-mode: 0 and no tracing headers, so RequestLogger/TracingInstrumentationHandler
+        // never call the many HttpServerExchange methods (getSourceAddress(), getRequestURL(), ...)
+        // that the module's test-only shadow HttpServerExchange does not implement.
+        var logging = new Logging(Level.INFO, false, null, true, true, false, List.of(), false, 0, List.of(), List.of(), 0L);
+        var configuration = mock(Configuration.class);
+        when(configuration.logging()).thenReturn(logging);
+        return configuration;
+    }
+
+    // -----------------------------------------------------------------------
+    // Test
+    // -----------------------------------------------------------------------
+
+    /**
+     * Drives a request through the exact pipeline {@code plugSseService} assembles (not a
+     * hand-built {@code SseWildcardInterceptorsExecutor} standing alone) and asserts that a
+     * denying {@code WildcardInterceptor} registered at {@code REQUEST_AFTER_AUTH} blocks the SSE
+     * handshake before the {@code SseService} is ever invoked.
+     *
+     * <p>This is the gap left by {@code SseWildcardInterceptorsExecutorTest}: every one of its
+     * tests constructs {@code SseWildcardInterceptorsExecutor} directly, so none of them would
+     * fail if the two {@code new SseWildcardInterceptorsExecutor(...)} lines were silently
+     * dropped from {@code plugSseService}'s {@code pipe(...)} call.
+     */
+    @Test
+    public void afterAuthDenyingWildcardInterceptorBlocksHandshakeThroughPlugSseServiceWiring() throws Exception {
+        var registry = PluginsRegistryImpl.getInstance();
+
+        // Save the real singleton's lazily-initialized fields so this test can restore them
+        // afterwards: PluginsRegistryImpl is a process-wide singleton shared with every other
+        // test in this JVM fork.
+        var savedInterceptors = getField(registry, "interceptors");
+        var savedAuthMechanisms = getField(registry, "authMechanisms");
+        var savedAuthorizers = getField(registry, "authorizers");
+        var savedTokenManager = getField(registry, "tokenManager");
+
+        try {
+            // Pre-seed the lazily-initialized fields so getAuthMechanisms()/getAuthorizers()/
+            // getTokenManager()/getInterceptors() (called by plugSseService() and by
+            // SseWildcardInterceptorsExecutor's constructor) do not fall through to
+            // PluginsFactory.getInstance(), which performs a real classpath scan requiring a
+            // fully bootstrapped Configuration.
+            setField(registry, "interceptors", new LinkedHashSet<PluginRecord<Interceptor<?, ?>>>());
+            setField(registry, "authMechanisms", new LinkedHashSet<PluginRecord<AuthMechanism>>());
+            setField(registry, "authorizers", new LinkedHashSet<PluginRecord<Authorizer>>());
+            setField(registry, "tokenManager", Optional.<PluginRecord<TokenManager>>empty());
+
+            var denier = new DenyingAfterAuthInterceptor();
+            registry.addInterceptor(interceptorRecord(denier));
+
+            var sseService = new RecordingSseService();
+            var sseRecord = new PluginRecord<SseService>(
+                    "plugSseServiceWiringTestSse",
+                    "test",
+                    false,
+                    true,
+                    RecordingSseService.class.getName(),
+                    sseService,
+                    null);
+
+            // Built before opening the Bootstrapper static mock below: nesting a second mock's
+            // when(...)/thenReturn(...) inside the argument expression of an outer, not-yet-completed
+            // when(...).thenReturn(...) chain confuses Mockito's (thread-local) stubbing state and
+            // fails with "UnfinishedStubbingException".
+            var configuration = configurationWithRequestLoggingDisabled();
+
+            try (MockedStatic<Bootstrapper> bootstrapperStatic = mockStatic(Bootstrapper.class)) {
+                bootstrapperStatic.when(Bootstrapper::getConfiguration).thenReturn(configuration);
+
+                // secured = false: the FullAuthorizer path, so this test needs no real
+                // authentication setup. It still runs both SseWildcardInterceptorsExecutor
+                // invocations: plugSseService always adds a fullAuthorizer to the authorizers
+                // set regardless of `secured`, so SecurityHandler always builds a
+                // SecurityInitialHandler -> AuthorizersHandler chain (never a bare pass-through),
+                // and REQUEST_BEFORE_AUTH / REQUEST_AFTER_AUTH are unconditionally part of the
+                // pipe(...) call below.
+                registry.plugSseService(sseRecord, URI, false);
+            }
+
+            var exchange = new HttpServerExchange();
+            exchange.setRequestPath(URI + "/clock");
+            exchange.setRequestMethod(new HttpString("GET"));
+
+            var handler = handlerPluggedFor(registry.getRootPathHandler(), URI + "/clock");
+            assertNotNull(handler, "plugSseService must have plugged a handler reachable from the root path handler for " + URI);
+
+            handler.handleRequest(exchange);
+
+            assertEquals(403, exchange.getStatusCode(),
+                    "the REQUEST_AFTER_AUTH WildcardInterceptor denial must reach the exchange as plugSseService wires it, "
+                            + "not just when SseWildcardInterceptorsExecutor is exercised standalone");
+            assertTrue(exchange.getSentContent() != null && exchange.getSentContent().contains("denied by plugSseService wiring test"),
+                    "the denial body must be sent to the client");
+            assertFalse(sseService.wasOnConnectCalled(),
+                    "the SSE handshake must never reach SseService.onConnect: the denial must short-circuit the pipeline");
+        } finally {
+            if (registry.getPipelineInfo(URI) != null) {
+                registry.unplug(URI, RegisterPlugin.MATCH_POLICY.PREFIX);
+            }
+            registry.removeInterceptorIf(i -> i.getInstance() instanceof DenyingAfterAuthInterceptor);
+
+            setField(registry, "interceptors", savedInterceptors);
+            setField(registry, "authMechanisms", savedAuthMechanisms);
+            setField(registry, "authorizers", savedAuthorizers);
+            setField(registry, "tokenManager", savedTokenManager);
+
+            assertNoLeakedPipeline(registry);
+        }
+    }
+
+    /**
+     * Confirms {@code unplug} left no trace of this test's pipeline in the shared registry, so it
+     * cannot affect other tests in this JVM fork.
+     */
+    private static void assertNoLeakedPipeline(PluginsRegistryImpl registry) throws ReflectiveOperationException {
+        assertEquals(null, handlerPluggedFor(registry.getRootPathHandler(), URI + "/clock"),
+                "unplug() must remove the handler plugged for " + URI + " from the root path handler");
+    }
+}

--- a/core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Fixes #716.

## The defect

A `WildcardInterceptor` registered at `REQUEST_AFTER_AUTH` runs for every `Service`, but never for an `SseService`. No SSE endpoint in RESTHeart could be authorized or inspected at the handshake — `secure = true` gave authentication and nothing more, and `SseService.onConnect` does not receive the authenticated account, so there was no module-local workaround either.

Four independent things in `PluginsRegistryImpl` all had to be true for an interceptor to resolve, and the SSE path satisfied none: `plugSseService` wires no `RequestInterceptorsExecutor`; it registers `PipelineInfo(PROXY, …)`; it never populates `services`/`servicesByName`, so `__interceptors` finds no handling service; and with no service present, the `WildcardInterceptor` shortcut in `__interceptors` is explicitly gated behind `_service.isPresent()`.

This was found while implementing topic-level authorization for the `mqtt` module (#601): the interceptor resolved for `/mqtt` and `/mqtt-sse`, worked on `/mqtt` (a `JsonService`), and was silently inert on `/mqtt-sse`. Its unit tests were green throughout, because they call it directly — nothing could observe that the framework never did.

## The approach

A dedicated `SseWildcardInterceptorsExecutor` that admits **only** `WildcardInterceptor`s, mirroring the shape of the existing `BeforeExchangeInitInterceptorsExecutor`, wired into `plugSseService` at `REQUEST_BEFORE_AUTH` (before the security handler) and `REQUEST_AFTER_AUTH` (after it).

The alternative — reclassifying the SSE pipeline as `SERVICE` — was rejected: it looks smaller but `ResponseSender:66,90`, `Request.java:108`, `Response.java:97` and `PluginUtils:377` all branch on the pipeline type. `plugService`, `RequestInterceptorsExecutor` and `PluginUtils` are untouched by this PR, and the SSE pipeline stays `PROXY`.

Interceptors run against a new minimal `ServiceRequest`/`ServiceResponse` pair in `commons`, `SseHandshakeRequest`/`SseHandshakeResponse`. `UninitializedRequest`/`UninitializedResponse` almost fit, but `UninitializedResponse.setInError` always throws by design — correct for its own intercept point, where denial is out of scope, but denial is the entire point here. Both are constructed with `dontAttach = true`, so `REQUEST_KEY`/`RESPONSE_KEY` are left alone and `ErrorHandler` and friends see the pipeline exactly as before.

## Commits

| | |
|---|---|
| `5ee86dec` | the executor, the `commons` pair, and the wiring in `plugSseService` |
| `c8696a70` | a denial raised at `REQUEST_BEFORE_AUTH` is deferred to after auth and sent with its status **and body** — it was arriving as a bare status with the message lost; plus `application/json` on the denial body, plus the licence headers the new files were missing |
| `b5dcbd88` | the pending-denial check is now reached even when nothing is registered at `REQUEST_AFTER_AUTH` |
| `d8b6e5a3` | a test proving `plugSseService` actually wires the executors in |

Commits 2-4 came out of review rather than the original plan, and two of them are worth reading on their own:

**`c8696a70`** — the two executors were creating separate, unattached response objects. `Exchange`'s in-error flag and the status code are exchange attachments, but `ServiceResponse.content` is an instance field, so a denial raised before auth arrived after auth as a status code with an empty body. The SERVICE pipeline does not have this problem because `RequestInterceptorsExecutor` uses the shared attached pair. Fixed by sharing one pair across both invocations via a dedicated `AttachmentKey` owned by the executor. This also corrected the class's own documentation, which had read `RequestInterceptorsExecutor`'s comment as "a denial before auth has no effect" when it actually means "deferred until after auth, then sent".

**`b5dcbd88`** — the executor returned early when it had no interceptors of its own, skipping the pending-denial check. A denial raised before auth was therefore dropped and the handshake proceeded: fail-open on an authorization path. It was masked only by accident — `dateHeader` and `xPoweredBy` are `enabledByDefault` `WildcardInterceptor`s that take `@RegisterPlugin`'s default `REQUEST_AFTER_AUTH`, so the list is never empty in a stock build. Disable those two cosmetic header setters in configuration and SSE authorization would have silently stopped being enforced. **The identical early return exists in `RequestInterceptorsExecutor` and is not fixed here** — it is a pre-existing defect on the SERVICE pipeline, filed separately as #717.

## Tests

`SseWildcardInterceptorsExecutorTest` (7) covers invocation, `resolve() == false`, non-wildcard exclusion, the deferred before-auth denial, the same with nothing registered at `REQUEST_AFTER_AUTH`, and the content type.

`PlugSseServiceWiringTest` (1) drives a request through the pipeline as `plugSseService` actually assembles it and asserts a denying interceptor blocks the handshake with `onConnect` never invoked. It exists because without it, deleting both `new SseWildcardInterceptorsExecutor(...)` lines from the `pipe(...)` call left every other test green — the whole fix could have been silently un-wired.

Each behavioural commit was validated with an explicit negative control: revert the implementation, confirm the test goes red for the stated reason, restore. Note for whoever re-runs the last one: with the wiring removed, `PlugSseServiceWiringTest` fails with a `NoSuchMethodError` rather than on its own assertion, because the request reaches the real `ServerSentEventHandler` and the test-only `HttpServerExchange` stand-in lacks `setPersistent`. That error *is* the evidence the request was not blocked.

Full `./mvnw -o -pl core -am -DskipITs test`: BUILD SUCCESS, 460 tests, 0 failures, 0 errors (commons 175, security 66, mongodb 128, accounts 11, stripe 54, core 26).

## Behaviour changes to be aware of

Every enabled `WildcardInterceptor` at these two intercept points now fires on SSE handshakes, where previously none did:

- `DateHeader`, `XPoweredBy` — add response headers before the stream starts, so no headers-already-committed conflict. SSE responses now carry a `Date` header, which they should have all along.
- `AuthCookieHandler` (`REQUEST_BEFORE_AUTH`) — cookie authentication now works on SSE handshakes.
- `BruteForceAttackGuard` — now protects SSE endpoints.
- `RequestsMetricsCollector` — SSE handshakes start being counted.
- `AuthCookieSetter` is at `RESPONSE` and is **not** affected.

## Porting

`9.x` carries the identical defect: the only difference in `PluginsRegistryImpl` between the branches is a one-line formatting change to `InterceptorCacheKey`, which does not overlap the edits here, so these commits should cherry-pick cleanly.

## Known limitation, deliberately not addressed

An SSE service cannot opt out of a specific interceptor the way a `Service` can via `@RegisterPlugin(dontIntercept = …)`; `requiredinterceptor` is likewise not honoured on this path. Additive follow-up if it is ever wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
