### PR TITLE
fix(core): don't drop a deferred before-auth denial when no interceptors run after auth (backport of #720 to 9.x)

### DIFF
--- a/core/src/main/java/org/restheart/handlers/RequestInterceptorsExecutor.java
+++ b/core/src/main/java/org/restheart/handlers/RequestInterceptorsExecutor.java
@@ -109,83 +109,85 @@ public class RequestInterceptorsExecutor extends PipelinedHandler {
         }
 
         if (interceptors.isEmpty()) {
+            // nothing of this executor's own to resolve/run, but a pending denial from the
+            // other invocation of this executor on the same exchange (REQUEST_BEFORE_AUTH's
+            // response is the very same request/response pair REQUEST_AFTER_AUTH reads above)
+            // must still reach the terminal check below: an empty list here must never bypass it.
             RequestPhaseContext.setPhase(Phase.INFO);
             LOGGER.debug("No interceptors found");
             RequestPhaseContext.setPhase(Phase.PHASE_END);
             LOGGER.debug("{} COMPLETED in 0ms", interceptPoint);
             RequestPhaseContext.reset();
-            next(exchange);
-            return;
-        }
-
-        // interceptors is already List<Interceptor<?,?>> - the instanceof/cast pair this
-        // replaced only stripped generics to the raw type so resolve()/handle() below can be
-        // called without a wildcard-capture mismatch against request/response (hence the
-        // rawtypes suppression on the method); it never filtered anything out. Stays null
-        // until the first match so the common "nothing resolves" case allocates nothing.
-        List<Interceptor> resolvedInterceptors = null;
-        for (var ri : interceptors) {
-            var interceptor = (Interceptor) ri;
-            try {
-                if (interceptor.resolve(request, response)) {
-                    if (resolvedInterceptors == null) {
-                        resolvedInterceptors = new ArrayList<>(interceptors.size());
+        } else {
+            // interceptors is already List<Interceptor<?,?>> - the instanceof/cast pair this
+            // replaced only stripped generics to the raw type so resolve()/handle() below can be
+            // called without a wildcard-capture mismatch against request/response (hence the
+            // rawtypes suppression on the method); it never filtered anything out. Stays null
+            // until the first match so the common "nothing resolves" case allocates nothing.
+            List<Interceptor> resolvedInterceptors = null;
+            for (var ri : interceptors) {
+                var interceptor = (Interceptor) ri;
+                try {
+                    if (interceptor.resolve(request, response)) {
+                        if (resolvedInterceptors == null) {
+                            resolvedInterceptors = new ArrayList<>(interceptors.size());
+                        }
+                        resolvedInterceptors.add(interceptor);
                     }
-                    resolvedInterceptors.add(interceptor);
-                }
-            } catch (Exception ex) {
-                LOGGER.warn("Error resolving interceptor {} for {} on intercept point {}", interceptor.getClass().getSimpleName(), exchange.getRequestPath(), interceptPoint, ex);
+                } catch (Exception ex) {
+                    LOGGER.warn("Error resolving interceptor {} for {} on intercept point {}", interceptor.getClass().getSimpleName(), exchange.getRequestPath(), interceptPoint, ex);
 
-                Exchange.setInError(exchange);
-                LambdaUtils.throwsSneakyException(new InterceptorException("Error resolving interceptor " + interceptor.getClass().getSimpleName(), ex));
+                    Exchange.setInError(exchange);
+                    LambdaUtils.throwsSneakyException(new InterceptorException("Error resolving interceptor " + interceptor.getClass().getSimpleName(), ex));
+                }
             }
-        }
-        if (resolvedInterceptors == null) {
-            resolvedInterceptors = List.of();
-        }
-
-        RequestPhaseContext.setPhase(Phase.INFO);
-        LOGGER.debug("Found {} interceptors", resolvedInterceptors.size());
-
-        // executionStartTime is only ever read by the debug log after the loop, so it's
-        // skipped entirely when debug is disabled instead of paying for a clock read that
-        // nothing will use. Per-interceptor timing below can't do the same: the error branch
-        // needs a duration unconditionally, so nanoTime() is used there for resolution instead
-        // (currentTimeMillis() is coarse enough to systematically show 0ms for fast interceptors).
-        var executionStartTime = LOGGER.isDebugEnabled() ? System.nanoTime() : 0L;
-        var totalInterceptors = resolvedInterceptors.size();
-
-        for (int i = 0; i < totalInterceptors; i++) {
-            var ri = resolvedInterceptors.get(i);
-            var interceptorStartTime = System.nanoTime();
-
-            try {
-                RequestPhaseContext.setPhase(Phase.ITEM);
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("{} (priority: {})", PluginUtils.name(ri), PluginUtils.priority(ri));
-                }
-
-                ri.handle(request, response);
-
-                RequestPhaseContext.setPhase(Phase.SUBITEM);
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("✓ {}ms", (System.nanoTime() - interceptorStartTime) / 1_000_000);
-                }
-            } catch (Exception ex) {
-                var interceptorDurationMs = (System.nanoTime() - interceptorStartTime) / 1_000_000;
-                RequestPhaseContext.setPhase(Phase.SUBITEM);
-                LOGGER.error("✗ FAILED after {}ms: {}", interceptorDurationMs, ex.getMessage());
-
-                Exchange.setInError(exchange);
-                LambdaUtils.throwsSneakyException(new InterceptorException("Error executing interceptor " + ri.getClass().getSimpleName(), ex));
+            if (resolvedInterceptors == null) {
+                resolvedInterceptors = List.of();
             }
-        }
 
-        RequestPhaseContext.setPhase(Phase.PHASE_END);
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("{} COMPLETED in {}ms", interceptPoint, (System.nanoTime() - executionStartTime) / 1_000_000);
+            RequestPhaseContext.setPhase(Phase.INFO);
+            LOGGER.debug("Found {} interceptors", resolvedInterceptors.size());
+
+            // executionStartTime is only ever read by the debug log after the loop, so it's
+            // skipped entirely when debug is disabled instead of paying for a clock read that
+            // nothing will use. Per-interceptor timing below can't do the same: the error branch
+            // needs a duration unconditionally, so nanoTime() is used there for resolution instead
+            // (currentTimeMillis() is coarse enough to systematically show 0ms for fast interceptors).
+            var executionStartTime = LOGGER.isDebugEnabled() ? System.nanoTime() : 0L;
+            var totalInterceptors = resolvedInterceptors.size();
+
+            for (int i = 0; i < totalInterceptors; i++) {
+                var ri = resolvedInterceptors.get(i);
+                var interceptorStartTime = System.nanoTime();
+
+                try {
+                    RequestPhaseContext.setPhase(Phase.ITEM);
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("{} (priority: {})", PluginUtils.name(ri), PluginUtils.priority(ri));
+                    }
+
+                    ri.handle(request, response);
+
+                    RequestPhaseContext.setPhase(Phase.SUBITEM);
+                    if (LOGGER.isDebugEnabled()) {
+                        LOGGER.debug("✓ {}ms", (System.nanoTime() - interceptorStartTime) / 1_000_000);
+                    }
+                } catch (Exception ex) {
+                    var interceptorDurationMs = (System.nanoTime() - interceptorStartTime) / 1_000_000;
+                    RequestPhaseContext.setPhase(Phase.SUBITEM);
+                    LOGGER.error("✗ FAILED after {}ms: {}", interceptorDurationMs, ex.getMessage());
+
+                    Exchange.setInError(exchange);
+                    LambdaUtils.throwsSneakyException(new InterceptorException("Error executing interceptor " + ri.getClass().getSimpleName(), ex));
+                }
+            }
+
+            RequestPhaseContext.setPhase(Phase.PHASE_END);
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("{} COMPLETED in {}ms", interceptPoint, (System.nanoTime() - executionStartTime) / 1_000_000);
+            }
+            RequestPhaseContext.reset();
         }
-        RequestPhaseContext.reset();
 
         // If an interceptor sets the response as errored
         // stop processing the request and send the response

--- a/core/src/test/java/io/undertow/server/HttpServerExchange.java
+++ b/core/src/test/java/io/undertow/server/HttpServerExchange.java
@@ -278,4 +278,12 @@ public class HttpServerExchange extends AbstractAttachable {
     public void setRelativePath(String relativePath) {
         this.relativePath = relativePath;
     }
+
+    /**
+     * @return whether the response has already started being sent; this fake never starts one,
+     *         so it always returns {@code false}
+     */
+    public boolean isResponseStarted() {
+        return false;
+    }
 }

--- a/core/src/test/java/org/restheart/handlers/RequestInterceptorsExecutorTest.java
+++ b/core/src/test/java/org/restheart/handlers/RequestInterceptorsExecutorTest.java
@@ -1,0 +1,341 @@
+/*-
+ * ========================LICENSE_START=================================
+ * restheart
+ * %%
+ * Copyright (C) 2014 - 2026 SoftInstigate
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * =========================LICENSE_END==================================
+ */
+
+package org.restheart.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+import org.restheart.exchange.Exchange;
+import org.restheart.exchange.PipelineInfo;
+import org.restheart.exchange.PipelineInfo.PIPELINE_TYPE;
+import org.restheart.exchange.Request;
+import org.restheart.exchange.ServiceRequest;
+import org.restheart.exchange.ServiceResponse;
+import org.restheart.exchange.StringRequest;
+import org.restheart.exchange.StringResponse;
+import org.restheart.plugins.Interceptor;
+import org.restheart.plugins.InterceptPoint;
+import org.restheart.plugins.PluginRecord;
+import org.restheart.plugins.PluginsRegistryImpl;
+import org.restheart.plugins.RegisterPlugin;
+import org.restheart.plugins.Service;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.HttpString;
+
+/**
+ * Proves that {@link RequestInterceptorsExecutor} defers, rather than drops, a denial raised
+ * via {@code response.setInError(...)} at {@code REQUEST_BEFORE_AUTH}: the denial must still be
+ * observed and sent once the {@code REQUEST_AFTER_AUTH} invocation of this executor runs, even
+ * when that invocation resolves zero interceptors of its own for the handling service
+ * (GitHub issue #717).
+ *
+ * <p>{@code PluginsRegistryImpl} is a process-wide singleton reached via a static
+ * {@code getInstance()} call, and {@link RequestInterceptorsExecutor} reads it directly in its
+ * constructor and in {@code handleRequest}. There is no seam to inject a fake registry, so these
+ * tests use {@code mockStatic(PluginsRegistryImpl.class)} to substitute a mock registry for the
+ * duration of each test, rather than mutating the real singleton (which is shared across the
+ * whole JVM).
+ *
+ * <p>The scenario is driven on the SERVICE pipeline (a fake {@link Service} plus
+ * {@link StringRequest}/{@link StringResponse}) rather than the PROXY pipeline: the PROXY
+ * response type ({@code ByteArrayProxyResponse}) buffers its content in pooled, connection-backed
+ * buffers that this test's fake {@code HttpServerExchange} has no connection for, whereas
+ * {@code StringResponse} keeps its content in a plain field. This is purely a test-construction
+ * choice; it exercises the exact same {@code handlingService != null} branch, and the same
+ * terminal deny-and-send/next decision, that {@link RequestInterceptorsExecutor} runs on the
+ * SERVICE pipeline in production.
+ *
+ * <p>{@code HttpServerExchange} is exercised via the module's existing test-only shadow class at
+ * {@code io.undertow.server.HttpServerExchange} (same fully-qualified name as Undertow's real,
+ * final class; this test source root takes precedence over the dependency jar for that name, both
+ * at compile time and at test runtime, so production code under test binds to the very same fake
+ * instance this test constructs). It was extended here with {@code isResponseStarted()}, the one
+ * method {@link ResponseSender} (invoked from the terminal deny branch) needs that the
+ * pre-existing shadow class did not yet provide; the fake always reports {@code false}, matching
+ * its existing behavior of never actually starting a response.
+ *
+ * @author Maurizio Turatti {@literal <maurizio@softinstigate.com>}
+ */
+public class RequestInterceptorsExecutorTest {
+
+    // -----------------------------------------------------------------------
+    // Test fixtures
+    // -----------------------------------------------------------------------
+
+    @RegisterPlugin(name = "denyingBeforeAuth", description = "denies at REQUEST_BEFORE_AUTH")
+    static class DenyingBeforeAuthInterceptor implements Interceptor<ServiceRequest<?>, ServiceResponse<?>> {
+        private final List<String> calls;
+
+        DenyingBeforeAuthInterceptor(List<String> calls) {
+            this.calls = calls;
+        }
+
+        @Override
+        public boolean resolve(ServiceRequest<?> request, ServiceResponse<?> response) {
+            return true;
+        }
+
+        @Override
+        public void handle(ServiceRequest<?> request, ServiceResponse<?> response) {
+            calls.add("denyingBeforeAuth");
+            // mirrors CollectionPropsInjector/DbPropsInjector/ContentSizeChecker/BruteForceAttackGuard:
+            // deny before auth, don't send yet (see RequestInterceptorsExecutor's REQUEST_AFTER_AUTH check)
+            response.setInError(403, "denied before auth", null);
+        }
+    }
+
+    @RegisterPlugin(name = "nonResolvingAfterAuth", description = "registered at REQUEST_AFTER_AUTH but never resolves")
+    static class NonResolvingAfterAuthInterceptor implements Interceptor<ServiceRequest<?>, ServiceResponse<?>> {
+        private final List<String> calls;
+
+        NonResolvingAfterAuthInterceptor(List<String> calls) {
+            this.calls = calls;
+        }
+
+        @Override
+        public boolean resolve(ServiceRequest<?> request, ServiceResponse<?> response) {
+            return false;
+        }
+
+        @Override
+        public void handle(ServiceRequest<?> request, ServiceResponse<?> response) {
+            calls.add("nonResolvingAfterAuth");
+        }
+    }
+
+    @RegisterPlugin(name = "testService", description = "test")
+    static class TestService implements Service<StringRequest, StringResponse> {
+        @Override
+        public Consumer<HttpServerExchange> requestInitializer() {
+            return StringRequest::init;
+        }
+
+        @Override
+        public Consumer<HttpServerExchange> responseInitializer() {
+            return StringResponse::init;
+        }
+
+        @Override
+        public Function<HttpServerExchange, StringRequest> request() {
+            return StringRequest::of;
+        }
+
+        @Override
+        public Function<HttpServerExchange, StringResponse> response() {
+            return StringResponse::of;
+        }
+    }
+
+    /** Records invocation order; stands in for the next handler in the pipeline (e.g. the security handler). */
+    static class RecordingHandler extends PipelinedHandler {
+        private final List<String> calls;
+        private final String label;
+
+        RecordingHandler(List<String> calls, String label) {
+            super(null);
+            this.calls = calls;
+            this.label = label;
+        }
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            calls.add(label);
+            next(exchange);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test helpers
+    // -----------------------------------------------------------------------
+
+    private static final String SERVICE_NAME = "testService";
+    private static final String PATH = "/test";
+
+    /**
+     * Builds a fake exchange wired as a SERVICE-pipeline request for {@link #SERVICE_NAME}:
+     * pipeline info attached, and the request/response pair created and attached exactly once,
+     * mirroring what {@code ServiceExchangeInitializer} does in production before either
+     * {@code RequestInterceptorsExecutor} invocation runs.
+     */
+    private static HttpServerExchange fakeServiceExchange() {
+        var exchange = new HttpServerExchange();
+        exchange.setRequestPath(PATH);
+        exchange.setRequestMethod(new HttpString("GET"));
+
+        Request.setPipelineInfo(exchange, new PipelineInfo(PIPELINE_TYPE.SERVICE, PATH, SERVICE_NAME));
+        StringRequest.init(exchange);
+        StringResponse.init(exchange);
+
+        return exchange;
+    }
+
+    private static PluginRecord<Service<?, ?>> serviceRecord(Service<?, ?> instance) {
+        return new PluginRecord<>(
+                SERVICE_NAME,
+                "test service",
+                false,
+                true, // enabledByDefault
+                instance.getClass().getName(),
+                instance,
+                null // confArgs
+        );
+    }
+
+    /**
+     * Substitutes {@code PluginsRegistryImpl.getInstance()} with a mock wired for the
+     * {@link #SERVICE_NAME} SERVICE pipeline: the service lookups {@link RequestInterceptorsExecutor}
+     * and {@link ResponseSender} need, plus the given interceptor lists per {@link InterceptPoint}.
+     */
+    private static AutoCloseable registryReturning(Service<?, ?> service,
+            List<Interceptor<?, ?>> beforeAuthInterceptors, List<Interceptor<?, ?>> afterAuthInterceptors) {
+        var record = serviceRecord(service);
+
+        var registryMock = mock(PluginsRegistryImpl.class);
+        when(registryMock.getService(SERVICE_NAME)).thenReturn(record);
+        when(registryMock.getServices()).thenReturn(Set.of(record));
+        when(registryMock.getPipelineInfo(PATH)).thenReturn(new PipelineInfo(PIPELINE_TYPE.SERVICE, PATH, SERVICE_NAME));
+        when(registryMock.getServiceInterceptors(same(service), eq(InterceptPoint.REQUEST_BEFORE_AUTH))).thenReturn(beforeAuthInterceptors);
+        when(registryMock.getServiceInterceptors(same(service), eq(InterceptPoint.REQUEST_AFTER_AUTH))).thenReturn(afterAuthInterceptors);
+
+        var registryStatic = mockStatic(PluginsRegistryImpl.class);
+        registryStatic.when(PluginsRegistryImpl::getInstance).thenReturn(registryMock);
+        return registryStatic;
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    /**
+     * The regression test for GitHub issue #717: nothing is registered at
+     * {@code REQUEST_AFTER_AUTH}, so that invocation's {@code interceptors} list is genuinely
+     * empty. The pending denial raised at {@code REQUEST_BEFORE_AUTH} must still be observed and
+     * sent: this must not depend on some other, unrelated interceptor happening to be registered
+     * at {@code REQUEST_AFTER_AUTH} for this service (in a stock build, interceptors such as
+     * DateHeader/XPoweredBy mask this by always being registered there by default).
+     */
+    @Test
+    public void beforeAuthDenialIsDeferredAndSentAtAfterAuthWhenNoAfterAuthInterceptorsRegistered() throws Exception {
+        var calls = new ArrayList<String>();
+        var denying = new DenyingBeforeAuthInterceptor(calls);
+        var service = new TestService();
+
+        try (var registryStatic = registryReturning(service, List.of(denying), List.of())) {
+            var exchange = fakeServiceExchange();
+
+            var nextHandlerStandIn = new RecordingHandler(calls, "next");
+            var afterAuthExecutor = new RequestInterceptorsExecutor(InterceptPoint.REQUEST_AFTER_AUTH);
+            var securityHandlerStandIn = new RecordingHandler(calls, "securityHandler");
+            var beforeAuthExecutor = new RequestInterceptorsExecutor(InterceptPoint.REQUEST_BEFORE_AUTH);
+
+            // wires: beforeAuthExecutor -> securityHandlerStandIn -> afterAuthExecutor -> nextHandlerStandIn
+            var pipeline = PipelinedHandler.pipe(beforeAuthExecutor, securityHandlerStandIn, afterAuthExecutor, nextHandlerStandIn);
+
+            pipeline.handleRequest(exchange);
+
+            assertEquals(List.of("denyingBeforeAuth", "securityHandler"), calls,
+                    "the before-auth interceptor and the security handler must run, but the pipeline must stop "
+                            + "at REQUEST_AFTER_AUTH once the deferred denial is observed, even though REQUEST_AFTER_AUTH "
+                            + "has no interceptors of its own for this service: the final next handler must never run");
+            assertTrue(Exchange.isInError(exchange), "the exchange must be flagged in error");
+            assertEquals(403, exchange.getStatusCode(),
+                    "the status code set by the REQUEST_BEFORE_AUTH denial must be the one sent after auth");
+            assertTrue(exchange.getSentContent() != null && exchange.getSentContent().contains("denied before auth"),
+                    "the body set by the REQUEST_BEFORE_AUTH denial must be the one sent after auth, not lost");
+        }
+    }
+
+    /**
+     * Positive control: an (unrelated, non-resolving) interceptor is registered at
+     * {@code REQUEST_AFTER_AUTH}, so that invocation's {@code interceptors} list is non-empty.
+     * This passes with or without the fix and proves nothing about the defect on its own; it
+     * exists to show the difference from the negative control above, which is the one that
+     * actually exercises the fix.
+     */
+    @Test
+    public void beforeAuthDenialIsDeferredAndSentAtAfterAuthWithAfterAuthInterceptorsRegistered() throws Exception {
+        var calls = new ArrayList<String>();
+        var denying = new DenyingBeforeAuthInterceptor(calls);
+        var nonResolving = new NonResolvingAfterAuthInterceptor(calls);
+        var service = new TestService();
+
+        try (var registryStatic = registryReturning(service, List.of(denying), List.of(nonResolving))) {
+            var exchange = fakeServiceExchange();
+
+            var nextHandlerStandIn = new RecordingHandler(calls, "next");
+            var afterAuthExecutor = new RequestInterceptorsExecutor(InterceptPoint.REQUEST_AFTER_AUTH);
+            var securityHandlerStandIn = new RecordingHandler(calls, "securityHandler");
+            var beforeAuthExecutor = new RequestInterceptorsExecutor(InterceptPoint.REQUEST_BEFORE_AUTH);
+
+            var pipeline = PipelinedHandler.pipe(beforeAuthExecutor, securityHandlerStandIn, afterAuthExecutor, nextHandlerStandIn);
+
+            pipeline.handleRequest(exchange);
+
+            assertEquals(List.of("denyingBeforeAuth", "securityHandler"), calls,
+                    "the REQUEST_AFTER_AUTH interceptor must be considered but not handled (its resolve() declines), "
+                            + "and the pipeline must stop at REQUEST_AFTER_AUTH once the deferred denial is observed");
+            assertEquals(403, exchange.getStatusCode(), "the deferred denial's status code must still be sent");
+            assertTrue(exchange.getSentContent() != null && exchange.getSentContent().contains("denied before auth"),
+                    "the deferred denial's body must still be sent");
+        }
+    }
+
+    /**
+     * Sanity check that the empty-list fast path still reaches {@code next(exchange)} normally
+     * when there is no pending denial at all: the restructuring must not turn every request into
+     * a deny-and-send.
+     */
+    @Test
+    public void noInterceptorsAtEitherPointForcesFastPathToNext() throws Exception {
+        var service = new TestService();
+
+        try (var registryStatic = registryReturning(service, List.of(), List.of())) {
+            var calls = new ArrayList<String>();
+            var exchange = fakeServiceExchange();
+
+            var nextHandlerStandIn = new RecordingHandler(calls, "next");
+            var afterAuthExecutor = new RequestInterceptorsExecutor(InterceptPoint.REQUEST_AFTER_AUTH);
+            var securityHandlerStandIn = new RecordingHandler(calls, "securityHandler");
+            var beforeAuthExecutor = new RequestInterceptorsExecutor(InterceptPoint.REQUEST_BEFORE_AUTH);
+
+            var pipeline = PipelinedHandler.pipe(beforeAuthExecutor, securityHandlerStandIn, afterAuthExecutor, nextHandlerStandIn);
+
+            pipeline.handleRequest(exchange);
+
+            assertEquals(List.of("securityHandler", "next"), calls, "with nothing denying, the whole pipeline must run through to the final next handler");
+            assertTrue(!Exchange.isInError(exchange), "the exchange must not be flagged in error");
+        }
+    }
+}


### PR DESCRIPTION
Backport of #720 to `9.x`. Deliberately not "Fixes #717" — that issue is already closed by the `master` merge and this PR should not reopen it.

`9.x` carries the defect identically: `RequestInterceptorsExecutor` returns early when it has no interceptors at its own intercept point, and that early return skips the check that turns a pending denial into a response. A request denied by a `REQUEST_BEFORE_AUTH` interceptor therefore reaches the service unblocked whenever the `REQUEST_AFTER_AUTH` list for that service is empty. See #717 for the analysis and #720 for the full rationale; none of it is `master`-specific.

The denial that matters most is `BruteForceAttackGuard`'s 429 — a security control that stops blocking. The triggering configuration is enabling `bruteForceAttackGuard` while disabling `dateHeader` and `xPoweredBy`, two actions that come from the same hardening motivation.

## What is in here

One commit: `b58eec37b` on `master` → `f67d84de4` here.

The second commit on `master`, `112e54f82` (`style(core): restore the spacing in the interceptor loop header`), was **skipped as empty**: it changed `master`'s `for (int i = 0;i < n;i++)` to the spaced form that `9.x` already had. It existed precisely so this port would converge, and it did its job — `RequestInterceptorsExecutor.java` is now byte-identical across the two branches.

## Conflict resolution

The cherry-pick conflicted once, in the restructured block, on that same `for` header. Resolved by taking `master`'s post-#720 version of the file wholesale, which is sound because the spacing was the *only* difference between the branches in this file before #720.

Verified in both directions rather than assumed:

- the resolved file is byte-identical to `master` at `112e54f82` (`git diff --stat` empty);
- against `9.x` before the port, the only semantic change (ignoring indentation) is the removal of `next(exchange); return;` and the move of the block into an `else`.

No hand-edited drift.

## Verification on this branch

`./mvnw -o -pl core -am -DskipITs test`: BUILD SUCCESS, **598 tests, 0 failures, 0 errors** (commons 225, security 68, mongodb 211, accounts 11, stripe 54, core 29). `RequestInterceptorsExecutorTest` runs here, 3/3 — `core` goes from 26 to 29 exactly as on `master`.

## Known limitation of the test, carried over

The regression test drives the **SERVICE** pipeline; the **PROXY** branch of this executor is not covered. `ByteArrayProxyResponse.setInError()` buffers its body in Undertow's pooled `PooledByteBuffer`s obtained from `exchange.getConnection().getByteBufferPool()`, and the test-only `io.undertow.server.HttpServerExchange` stand-in has no `ServerConnection` fake. The fix applies to both branches; the proof covers one. Pre-existing limitation of that scaffolding, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
